### PR TITLE
Fix links to the GitHub repo

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -32,4 +32,4 @@ max_toc_heading_level: 2
 prevent_indexing: false
 
 show_contribution_banner: true
-github_repo: moj-analytical-services
+github_repo: moj-analytical-services/user-guidance


### PR DESCRIPTION
This PR will:
- correct the `github_repo` parameter in the `tech_docs.yaml` config
- ensure that the 'GitHub repo' and 'Report issue' links on each page work correctly