### PR TITLE
Fixing upload file to s3 from python typo

### DIFF
--- a/source/documentation/amazon-s3.md
+++ b/source/documentation/amazon-s3.md
@@ -159,7 +159,7 @@ To upload a file to Amazon S3, use the following code:
 import boto3
 
 s3 = boto3.resource('s3')
-s3.object('bucket_name', 'key').put(Body=object)
+s3.Object('bucket_name', 'key').put(Body=object)
 ```
 
 If you receive an `ImportError`, try restarting your kernel, so that Python recognises your `boto3` installation.


### PR DESCRIPTION
The line in upload to s3 from python had a lower case `o` in `object` when it needed to be uppercase, causing an error. A few people were having trouble with it. 