### PR TITLE
Changed data-engineering-infrastrure to data-engineering-database-access

### DIFF
--- a/source/documentation/data-docs/curated-databases-docs/databases.md
+++ b/source/documentation/data-docs/curated-databases-docs/databases.md
@@ -2,7 +2,7 @@
 
 The data engineering team curate and maintain databases on the Analytical Platform that can be made accessible to users. All of our databases are currently deployed and accessible using Amazon Athena. We currently support users being able to query these databases via the [Athena SQL workbench](#amazon-athena), [R and Python](#dbtools).
 
-To see what databases are available and how to request access, see the [README](https://github.com/moj-analytical-services/data-engineering-infrastructure/blob/master/README.md) in the [data-engineering-infrastructure](https://github.com/moj-analytical-services/data-engineering-infrastructure) repository on GitHub.
+To see what databases are available and how to request access, see the [README](https://github.com/moj-analytical-services/data-engineering-database-access/blob/master/README.md) in the [data-engineering-database-access](https://github.com/moj-analytical-services/data-engineering-database-access) repository on GitHub.
 
 > Note, you must be a member of the [moj-analytical-services](https://github.com/moj-analytical-services) GitHub organisation to access the repository.
 


### PR DESCRIPTION
We've renamed the data-engineering-infrastructure repo to data-engineering-database-access. This pull request is to make the same change in the user guidance where it mentions the old name. 