### PR TITLE
Swap order of airflow and builds

### DIFF
--- a/source/airflow.html.md.erb
+++ b/source/airflow.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Airflow
-weight: 80
+weight: 90
 ---
 
 <%= partial 'documentation/airflow' %>

--- a/source/build-deploy.html.md.erb
+++ b/source/build-deploy.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Build and deploy
-weight: 90
+weight: 80
 ---
 
 <%= partial 'documentation/build-deploy' %>


### PR DESCRIPTION
So that keep the builds info follows on from the sections on Shiny+web app - these seem logically much closer related.