### PR TITLE
Fix render of table

### DIFF
--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -24,7 +24,7 @@ To create a new repository based on the Shiny app template:
 1. Go to the [rshiny-template](https://github.com/moj-analytical-services/rshiny-template) repository.
 2. Press the "Branch: master" button and choose a suitable branch, according to the requirements of your app:
 
-    | Branch | How it will run your Shiny app   |
+    | Branch | How it will run your R Shiny app   |
     |--------|----------------------------------|
     | master | R 3.5.1 with Conda packaging     |
     | r-3.4  | R 3.4.2 with Packrat packaging   |

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -29,7 +29,7 @@ To create a new repository based on the Shiny app template:
     | master | R 3.5.1 with Conda packaging     |
     | r-3.4  | R 3.4.2 with Packrat packaging   |
 
-    It's recommended when you start a new project to upgrade your R Studio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in R Studio.
+    It's recommended, when you start a new project, to upgrade your RStudio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in RStudio.
 
 3. Select __Use this template__.
 4. Fill in the form:

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -27,7 +27,7 @@ To create a new repository based on the Shiny app template:
     | Branch | How it will run your R Shiny app   |
     |--------|----------------------------------|
     | master | R 3.5.1 with conda packaging     |
-    | r-3.4  | R 3.4.2 with Packrat packaging   |
+    | r-3.4  | R 3.4.2 with packrat packaging   |
 
     It's recommended, when you start a new project, to upgrade your RStudio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in RStudio.
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -24,12 +24,13 @@ To create a new repository based on the Shiny app template:
 1. Go to the [rshiny-template](https://github.com/moj-analytical-services/rshiny-template) repository.
 2. Press the "Branch: master" button and choose a suitable branch, according to the requirements of your app:
 
-   | Branch | How it will run your Shiny app   |
-   |--------|----------------------------------|
-   | master | R 3.5.1 with Conda packaging |
-   | r-3.4  | R 3.4.2 with Packrat packaging |
+    | Branch | How it will run your Shiny app   |
+    |--------|----------------------------------|
+    | master | R 3.5.1 with Conda packaging     |
+    | r-3.4  | R 3.4.2 with Packrat packaging   |
 
-   It's recommended when you start a new project to upgrade your R Studio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in R Studio.
+    It's recommended when you start a new project to upgrade your R Studio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in R Studio.
+
 3. Select __Use this template__.
 4. Fill in the form:
     + Owner: `moj-analytical-services`

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -26,7 +26,7 @@ To create a new repository based on the Shiny app template:
 
     | Branch | How it will run your R Shiny app   |
     |--------|----------------------------------|
-    | master | R 3.5.1 with Conda packaging     |
+    | master | R 3.5.1 with conda packaging     |
     | r-3.4  | R 3.4.2 with Packrat packaging   |
 
     It's recommended, when you start a new project, to upgrade your RStudio version to the latest offered in Control Panel, and select an R Shiny template from this list that matches the R version you have in RStudio.


### PR DESCRIPTION
In a numbered list, follow-on paragraphs need 4+ chars of indent, with this markdown renderer, it seems.

Before:
![Screen Shot 2020-05-22 at 10 54 12](https://user-images.githubusercontent.com/307612/82655771-3c1b7c00-9c12-11ea-998f-ecb1e5ecdb95.png)

After:
![Screen Shot 2020-05-22 at 10 53 57](https://user-images.githubusercontent.com/307612/82655778-3e7dd600-9c12-11ea-8f51-96edbe882e22.png)
