### PR TITLE
Move packrat info to the Package Management page

### DIFF
--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -80,7 +80,7 @@ By default, the template contains `server.R` and `ui.R` files. However, you may 
 
 ### List your package dependencies
 
-Most apps will have dependencies on various third-party packages (e.g., `dplyr`).
+Most apps will have dependencies on various third-party packages (for example, `dplyr`).
 
 In your project repo you will need a file that lists your dependencies. We use 'package management' to management these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see: [package management](tools.html#managing-your-analytical-tools).
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -78,21 +78,17 @@ Your app can take one of several forms:
 
 By default, the template contains `server.R` and `ui.R` files. However, you may wish to take a different approach depending on your requirements. For example, using `app.R`, it is possible to deploy RShiny apps from within a package, as in this [example from the costmodelr package](https://github.com/RobinL/costmodelr/blob/b328902026bd1cce5d17b487e310c59725ea4d62/R/shiny_explorer.r#L20).
 
-### Manage dependencies
+### List your package dependencies
 
-Most apps will have dependencies on various third-party packages (e.g., `dplyr`). These packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as packrat, renv, or conda.
+Most apps will have dependencies on various third-party packages (e.g., `dplyr`).
 
-You can find further guidance in the [package management](https://user-guidance.services.alpha.mojanalytics.xyz/appendix/conda/#package-management) section.
+In your project repo you will need a file that lists your dependencies. We use 'package management' to management these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see: [package management](tools.html#managing-your-analytical-tools).
 
-If using packrat, ensure that it is enabled for your project in RStudio.
+If using conda, you will need to [list your dependencies in your project's environment.yml](tools.html#exporting-your-environment).
 
-To enable packrat, select __Tools__ > __Project Options...__ > __Packrat__ > __Use packrat with this project__.
+If using packrat, you will need to [list your dependencies in your project's packrat/packrat.lock](tools.html#packrat-usage).
 
-When packrat is enabled, run `packrat::snapshot()` to generate a list of packages used in the project, their sources and their current versions.
-
-You may also wish to run `packrat::clean()` to remove unused packages from the list.
-
-The list is stored in a file called `packrat/packrat.lock`. You must ensure that you have committed this file to GitHub before deploying your app.
+(During the Concourse build of an app, the app repo's Dockerfile has a command to install packages in the list.)
 
 ### Set access permissions
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -82,7 +82,7 @@ By default, the template contains `server.R` and `ui.R` files. However, you may 
 
 Most apps will have dependencies on various third-party packages (for example, `dplyr`).
 
-In your project repo you will need a file that lists your dependencies. We use 'package management' to management these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see: [package management](tools.html#managing-your-analytical-tools).
+In your project repository you will need a file that lists your dependencies. We use 'package management' to manage these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see the [package management](tools.html#managing-your-analytical-tools) section.
 
 If using conda, you will need to [list your dependencies in your project's environment.yml](tools.html#exporting-your-environment).
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -88,7 +88,7 @@ If using conda, you will need to [export your dependencies](tools.html#exporting
 
 If using packrat, you will need to [export your dependencies](tools.html#packrat-usage) to a `packrat/packrat.lock` file.
 
-(During the Concourse build of an app, the app repo's Dockerfile has a command to install packages in the list.)
+The Dockerfile in the app's repository contains a command to install the packages in the list. This command will be run when Concourse builds the app.
 
 ### Set access permissions
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -84,7 +84,7 @@ Most apps will have dependencies on various third-party packages (for example, `
 
 In your project repository you will need a file that lists your dependencies. We use 'package management' to manage these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see the [package management](tools.html#managing-your-analytical-tools) section.
 
-If using conda, you will need to [list your dependencies in your project's environment.yml](tools.html#exporting-your-environment).
+If using conda, you will need to [export your dependencies](tools.html#exporting-your-environment) to an `environment.yml` file.
 
 If using packrat, you will need to [export your dependencies](tools.html#packrat-usage) to a `packrat/packrat.lock` file.
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -86,7 +86,7 @@ In your project repository you will need a file that lists your dependencies. We
 
 If using conda, you will need to [list your dependencies in your project's environment.yml](tools.html#exporting-your-environment).
 
-If using packrat, you will need to [list your dependencies in your project's packrat/packrat.lock](tools.html#packrat-usage).
+If using packrat, you will need to [export your dependencies](tools.html#packrat-usage) to a `packrat/packrat.lock` file.
 
 (During the Concourse build of an app, the app repo's Dockerfile has a command to install packages in the list.)
 

--- a/source/documentation/tools.md
+++ b/source/documentation/tools.md
@@ -185,6 +185,16 @@ It has some significant downsides. It can be quite temperamental, and difficult 
 
 Furthermore, the Analytical Platform version of RStudio runs on a Linux virtual machine, and CRAN mirrors do not provide Linux compiled binaries for packages. This means that packages need to be compiled on the Analytical Platform every time they're installed, which can take a long time. This means a long wait when doing `install.packages` both in an RStudio session, and when running a Docker build for an RShiny application.
 
+### Packrat usage
+
+To use packrat, ensure that it is enabled for your project in RStudio: select __Tools__ > __Project Options...__ > __Packrat__ > __Use packrat with this project__.
+
+When packrat is enabled, run `packrat::snapshot()` to generate a list of packages used in the project, their sources and their current versions.
+
+You may also wish to run `packrat::clean()` to remove unused packages from the list.
+
+The list is stored in a file called `packrat/packrat.lock`. You must ensure that you have committed this file to GitHub before deploying your app.
+
 ### Renv
 
 [Renv](https://rstudio.github.io/renv/articles/renv.html) is a newer package billed as "Packrat 2.0". This has a number of improvements over Packrat, in the speed of download and reduction of issues of 00LOCK files that often plague Packrat. However, it is still not able to deal with OS-level dependencies, so conda is still preferred.


### PR DESCRIPTION
Now we have the tools page with all the package management stuff there, let's put there this snippet about using packrat. And provide a link there, as well as the conda equivalent.