### PR TITLE
Corrected link pointing to information governance from Amazon S3 section

### DIFF
--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -105,7 +105,7 @@ To remove a user from the data access group:
 
 You can upload files to Amazon S3 from your local computer or from RStudio or JupyterLab.
 
-When uploading files to Amazon S3, you should ensure that you follow all necessary [information governance](../information-governance.html) procedures. In particular, you must complete a data movement form when moving any data onto the Analytical Platform.
+When uploading files to Amazon S3, you should ensure that you follow all necessary [information governance](../../information-governance.html) procedures. In particular, you must complete a data movement form when moving any data onto the Analytical Platform.
 
 ### Amazon S3 Console
 


### PR DESCRIPTION
> "Hi, just reading the data upload rules for the AP in the user guide and I've noticed the link to the information governance rules is broken (https://user-guidance.services.alpha.mojanalytics.xyz/data/information-governance.html), could I please get a link to the working version? Thanks"

The link was pointing to `../information-governance.html` from `/data/amazon-s3.html` resulting in the 404 `https://user-guidance.services.alpha.mojanalytics.xyz/data/information-governance.html`.

I've changed it to point to `../../information-governance.html`, but am open to other suggestions.