### PR TITLE
Default to "internal" repos

### DIFF
--- a/source/documentation/airflow.md
+++ b/source/documentation/airflow.md
@@ -49,7 +49,7 @@ To create a new repository from the Airflow template:
 3. Fill in the form:
     + Owner: `moj-analytical-services`
     + Name: The name of your pipeline prefixied with `airflow-`, for example, `airflow-my-pipeline`
-    + Privacy: Private
+    + Privacy: Internal (refer to the [public, internal and private repositories](github.html#public-internal-and-private-repositories) section)
 4. Select __Create repository from template__.
 
 This copies the entire contents of the Airflow template to a new repository.

--- a/source/documentation/build-deploy.md
+++ b/source/documentation/build-deploy.md
@@ -16,7 +16,7 @@ Changes to deploy.json only take effect when committed to GitHub (master branch)
 
 ## Starting a build/deploy
 
-To trigger a Concourse build/deploy, make sure your code is committed and pushed to GitHub and then [create a release on GitHub](https://help.github.com/articles/creating-releases/). Call the first release `v0.0.1`, then `v0.0.2` etc. The version should always go up in number, or it won't build. It's good practise to use [semantic versioning](https://semver.org/).
+To trigger a Concourse build/deploy, make sure your code is committed and pushed to GitHub and then [create a release on GitHub](https://help.github.com/articles/creating-releases/). It's good practise to use [semantic versioning](https://semver.org/), for example to call the first release `v0.0.1`, then `v0.0.2` etc. The version should always go up in number: concourse automatically looks for a version higher than the one it last deployed, so if your latest release has a version number lower than the currently deployed version it won't build. [You can check your version order here.](https://semvercompare.azurewebsites.net/).
 
 Your task appears in Concourse within 30 seconds. Find it in Concourse to start it as follows:
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -78,21 +78,17 @@ Your app can take one of several forms:
 
 By default, the template contains `server.R` and `ui.R` files. However, you may wish to take a different approach depending on your requirements. For example, using `app.R`, it is possible to deploy RShiny apps from within a package, as in this [example from the costmodelr package](https://github.com/RobinL/costmodelr/blob/b328902026bd1cce5d17b487e310c59725ea4d62/R/shiny_explorer.r#L20).
 
-### Manage dependencies
+### List your package dependencies
 
-Most apps will have dependencies on various third-party packages (e.g., `dplyr`). These packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as packrat, renv, or conda.
+Most apps will have dependencies on various third-party packages (for example, `dplyr`).
 
-You can find further guidance in the [package management](https://user-guidance.services.alpha.mojanalytics.xyz/appendix/conda/#package-management) section.
+In your project repository you will need a file that lists your dependencies. We use 'package management' to manage these lists. The packages change through time and may not always be backwards compatible. To avoid compatibility issues and ensure reproducible outputs, it is necessary to use a package management system, such as conda, packrat or renv. For further guidance see the [package management](tools.html#managing-your-analytical-tools) section.
 
-If using packrat, ensure that it is enabled for your project in RStudio.
+If using conda, you will need to [export your dependencies](tools.html#exporting-your-environment) to an `environment.yml` file.
 
-To enable packrat, select __Tools__ > __Project Options...__ > __Packrat__ > __Use packrat with this project__.
+If using packrat, you will need to [export your dependencies](tools.html#packrat-usage) to a `packrat/packrat.lock` file.
 
-When packrat is enabled, run `packrat::snapshot()` to generate a list of packages used in the project, their sources and their current versions.
-
-You may also wish to run `packrat::clean()` to remove unused packages from the list.
-
-The list is stored in a file called `packrat/packrat.lock`. You must ensure that you have committed this file to GitHub before deploying your app.
+The Dockerfile in the app's repository contains a command to install the packages in the list. This command will be run when Concourse builds the app.
 
 ### Set access permissions
 

--- a/source/documentation/rshiny-app.md
+++ b/source/documentation/rshiny-app.md
@@ -35,7 +35,7 @@ To create a new repository based on the Shiny app template:
 4. Fill in the form:
     * Owner: `moj-analytical-services`
     * Name: The name of your app, for example, `my-app`
-    * Privacy: Private
+    * Privacy: Internal (refer to the [public, internal and private repositories](github.html#public-internal-and-private-repositories) section)
 5. Select __Create repository from template__. This copies the entire contents of the app template to a new repository.
 
 ### Create a new webapp

--- a/source/documentation/static-app.md
+++ b/source/documentation/static-app.md
@@ -24,7 +24,7 @@ To create a new repository based on the webapp template:
 3. Fill in the form:
     + Owner: `moj-analytical-services`
     + Name: The name of your app, for example, `my-app`
-    + Privacy: Private
+    + Privacy: Internal (refer to the [public, internal and private repositories](github.html#public-internal-and-private-repositories) section)
 4. Select __Create repository from template__.
 
 This copies the entire contents of the app template to a new repository.

--- a/source/documentation/tools.md
+++ b/source/documentation/tools.md
@@ -338,6 +338,16 @@ It has some significant downsides. It can be quite temperamental, and difficult 
 
 Furthermore, the Analytical Platform version of RStudio runs on a Linux virtual machine, and CRAN mirrors do not provide Linux compiled binaries for packages. This means that packages need to be compiled on the Analytical Platform every time they're installed, which can take a long time. This means a long wait when doing `install.packages` both in an RStudio session, and when running a Docker build for an RShiny application.
 
+### Packrat usage
+
+To use packrat, ensure that it is enabled for your project in RStudio: select __Tools__ > __Project Options...__ > __Packrat__ > __Use packrat with this project__.
+
+When packrat is enabled, run `packrat::snapshot()` to generate a list of packages used in the project, their sources and their current versions.
+
+You may also wish to run `packrat::clean()` to remove unused packages from the list.
+
+The list is stored in a file called `packrat/packrat.lock`. You must ensure that you have committed this file to GitHub before deploying your app.
+
 ### Renv
 
 [Renv](https://rstudio.github.io/renv/articles/renv.html) is a newer package billed as "Packrat 2.0". This has a number of improvements over Packrat, in the speed of download and reduction of issues of 00LOCK files that often plague Packrat. However, it is still not able to deal with OS-level dependencies, so conda is still preferred.


### PR DESCRIPTION
Because that's the most common, and a sensible default. Private that is not very good for sharing, so should be only used in rare circumstances, as explained in the linked guidance.