### PR TITLE
Update instructions for soft reset of conda environment

### DIFF
--- a/source/documentation/tools.md
+++ b/source/documentation/tools.md
@@ -216,7 +216,7 @@ single conda environment available. This means having to be careful to make sure
 This is recommended to run before starting a new project. This will ensure that no unused dependencies are exported when you export an `environment.yml` for this project.
 
 ```bash
-conda env export -n base| grep -v "^prefix: " > /tmp/base.yml && conda env update --prune -n rstudio -f /tmp/base.yml && rm /tmp/base.yml
+conda env export -n base| grep -v "^prefix: " > /tmp/base.yml && conda env create --force -n rstudio -f /tmp/base.yml && rm /tmp/base.yml
 ```
 
 #### Hard reset of your environment
@@ -318,7 +318,7 @@ Alternatively, if you use `conda search PACKAGENAME`, you can look in the Field 
 
 ![](images/conda/conda_search_R_version_number_example.PNG)
 
-If there isn't an appropriate build for a package, attempting to `conda install` that package will result in conda attempting to match the environment to the superior (or inferior) version of R, asking if you want to install/upgrade/downgrade a long list of packages in the process. 
+If there isn't an appropriate build for a package, attempting to `conda install` that package will result in conda attempting to match the environment to the superior (or inferior) version of R, asking if you want to install/upgrade/downgrade a long list of packages in the process.
 
 Instead, you should install the package locally via `install.packages()` or `remotes::install_github()`. For RShiny apps, you can add an `install.packages()` step to the `Dockerfile` to install additional packages not covered by the conda environment.yml, like so:
 


### PR DESCRIPTION
The current documented method of resetting a conda environment doesn't work due to the purge function being broken function in the latest version of conda.

https://github.com/conda/conda/issues/7279

This is the suggested workaround.

`conda env create --force -n rstudio -f /tmp/base.yml`