### PR TITLE
Fix incorrectly rendered underscores in dash.md

### DIFF
--- a/source/documentation/appendix-docs/dash.md
+++ b/source/documentation/appendix-docs/dash.md
@@ -5,10 +5,10 @@ preview that web app before you deploy it. The Analytical Platform provides a sp
 endpoints under `/\_tunnel\_/<portNumber>/` that route to exposed HTTP ports on
 the localhost. There are a few things you need to keep in mind:
 
-* `<portNumber>` can only be one from a limited range. By default, you can only route
+- `<portNumber>` can only be one from a limited range. By default, you can only route
   to ports 8050 and 4040--4050 inclusive. You should make your web app listen on
   one of those.
-* The `/_tunnel_/<portNumber>/` endpoint will only tunnel to services bound to a
+- The `/_tunnel_/<portNumber>/` endpoint will only tunnel to services bound to a
   non--public IP address. By default, many web frameworks bind to host `127.0.0.1`.
   You will need to change this to `0.0.0.0` or the tunnel won't work. This is to
   prevent inadvertently exposing webapps to the tunnel.
@@ -34,6 +34,7 @@ dependencies by adding these to either `requirements.txt` and `pip` or
 `environment.yaml` and `conda`.
 
 ### Example code
+
 Save the Dash hello world app to a new python file called `app.py`:
 
 ```python
@@ -104,8 +105,8 @@ There are two important things to note here, where this code differs from the
 Plotly Dash example:
 
 1. The `Dash` class must be instantiated with a `url_base_pathname`. This should
-always be `/_tunnel_/8050/` e.g.
-`app = dash.Dash('app', server=server, url_base_pathname='/_tunnel_/8050/')`.
+   always be `/_tunnel_/8050/` e.g.
+   `app = dash.Dash('app', server=server, url_base_pathname='/_tunnel_/8050/')`.
 
 2. When you run the server, it must be bound to `0.0.0.0`, e.g., `app.run_server(host='0.0.0.0')`.
 

--- a/source/documentation/appendix-docs/dash.md
+++ b/source/documentation/appendix-docs/dash.md
@@ -147,4 +147,4 @@ alternatively, contact us by [email](mailto:analytical_platform@digital.justice.
 to request an upgrade.
 
 [dash]: https://dash.plot.ly/
-[Slack channel]: (https://asdslack.slack.com/messages/anaytical_platform/
+[Slack channel]: https://asdslack.slack.com/messages/anaytical_platform/

--- a/source/documentation/appendix-docs/dash.md
+++ b/source/documentation/appendix-docs/dash.md
@@ -2,7 +2,7 @@
 
 If you are developing a web application using Jupyter you will probably want to
 preview that web app before you deploy it. The Analytical Platform provides a special set of
-endpoints under `/_tunnel_/<portNumber>/` that route to exposed HTTP ports on
+endpoints under `/\_tunnel\_/<portNumber>/` that route to exposed HTTP ports on
 the localhost. There are a few things you need to keep in mind:
 
 * `<portNumber>` can only be one from a limited range. By default, you can only route
@@ -52,7 +52,7 @@ server.secret_key = os.environ.get('secret_key', 'secret')
 
 df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/hello-world-stock.csv')
 
-app = dash.Dash('app', server=server, url_base_pathname='/_tunnel_/8050/')
+app = dash.Dash('app', server=server, url_base_pathname='/\_tunnel\_/8050/')
 
 app.scripts.config.serve_locally = False
 dcc._js_dist[0]['external_url'] = 'https://cdn.plot.ly/plotly-basic-latest.min.js'
@@ -95,7 +95,7 @@ def update_graph(selected_dropdown_value):
         }
     }
 
-if __name__ == '__main__':
+if `__name__` == '\_\_main\_\_':
     app.run_server(host='0.0.0.0')
 
 ```
@@ -113,26 +113,26 @@ always be `/_tunnel_/8050/` e.g.
 
 ### Run server from the terminal
 
-```sh
+```
 $ python3 app.py
- * Serving Flask app "app" (lazy loading)
- * Environment: production
-   WARNING: Do not use the development server in a production environment.
-   Use a production WSGI server instead.
- * Debug mode: off
- * Running on http://0.0.0.0:8050/ (Press CTRL+C to quit)
+ \* Serving Flask app "app" (lazy loading)
+ \* Environment: production
+    WARNING: Do not use the development server in a production environment.
+    Use a production WSGI server instead.
+ \* Debug mode: off
+ \* Running on http://0.0.0.0:8050/ (Press CTRL+C to quit)
 ```
 
-### Access via `_tunnel_` URL
+### Access via `\_tunnel\_` URL
 
-Copy your `jupyter` URL and append `/_tunnel_/8050/` to access your running Dash
+Copy your `jupyter` URL and append `/\_tunnel\_/8050/` to access your running Dash
 app. If your `jupyter` URL is `https://r4vi-jupyter-lab.tools.alpha.mojanalytics.xyz/lab?`,
 then your Dash app will be available at
-`https://r4vi-jupyter-lab.tools.alpha.mojanalytics.xyz/_tunnel_/8050/`.
+`https://r4vi-jupyter-lab.tools.alpha.mojanalytics.xyz/\_tunnel\_/8050/`.
 
 ![](images/dash/visit_url.gif)
 
-#### Who can access this `/_tunnel_/` URL?
+#### Who can access the `\_tunnel\_` URL?
 
 Only you can access the URL and it can not be shared with other members of your
 team. It is intended for testing while developing an application.


### PR DESCRIPTION
Some underscores in code chunks are being incorrectly interpreted as italic markers. This PR will escape the relevant underscores in order that they are rendered correctly. It will also fix some minor markdown formatting issues and fix a broken link.

Partially fixes #9.