### PR TITLE
Fix link to AP Acceptable Use Policy

### DIFF
--- a/source/documentation/get-started.md
+++ b/source/documentation/get-started.md
@@ -6,7 +6,7 @@ You need an account before you can use the Analytical Platform. To do this, comp
 
 ### Read the acceptable use policy and coding standards
 
-Use of the Analytical Platform is subject to our [acceptable use policy](https://github.com/moj-analytical-services/user-guidance/blob/master/source/documentation/aup.md). You should ensure that you have read and understood this before using the Analytical Platform.
+Use of the Analytical Platform is subject to our [acceptable use policy](https://user-guidance.services.alpha.mojanalytics.xyz/aup.html). You should ensure that you have read and understood this before using the Analytical Platform.
 
 You should also follow our [coding standards](https://github.com/moj-analytical-services/our-coding-standards) when working on the Analytical Platform. These set out principles that you should follow when writing and reviewing code.
 

--- a/source/documentation/get-started.md
+++ b/source/documentation/get-started.md
@@ -6,7 +6,7 @@ You need an account before you can use the Analytical Platform. To do this, comp
 
 ### Read the acceptable use policy and coding standards
 
-Use of the Analytical Platform is subject to our [acceptable use policy](#acceptable-use-policy). You should ensure that you have read and understood this before using the Analytical Platform.
+Use of the Analytical Platform is subject to our [acceptable use policy](https://github.com/moj-analytical-services/user-guidance/blob/master/source/documentation/aup.md). You should ensure that you have read and understood this before using the Analytical Platform.
 
 You should also follow our [coding standards](https://github.com/moj-analytical-services/our-coding-standards) when working on the Analytical Platform. These set out principles that you should follow when writing and reviewing code.
 


### PR DESCRIPTION
The link to the acceptable use policy in the user guidance is broken, this should hopefully fix it.