### PR TITLE
Update GITHUB_PAT guidance

### DIFF
--- a/source/documentation/github.md
+++ b/source/documentation/github.md
@@ -329,7 +329,7 @@ To generate your PAT for reading private repos in R:
 
 ### Using a PAT to authenticate in R/RStudio
 
-You should store your PAT in a special R file, called .Renviron, in your *home directory* (on AP). This file gets run when you start R, putting the PAT into the system environment variable `GITHUB_PAT`. This is where common R packages (e.g. remotes, devtools and renv) will look for it.
+You should store your PAT in a special R file, called `.Renviron` in your home directory on the Analytical Platform. This file gets run when you start R, putting the PAT into the system environment variable `GITHUB_PAT`. This is where common R packages (for example, remotes, devtools and renv) will look for it.
 
 Set this up by running this in your R console (you only need to run it once; do **not** save this line in any file in any repo) and substitute your own PAT Token in place of the example PAT `ax451...8838b1` below:
   

--- a/source/documentation/github.md
+++ b/source/documentation/github.md
@@ -315,8 +315,7 @@ You can get a PAT from your GitHub user profile. A user can generate a number of
 
 To generate your PAT for reading private repos in R:
 
-  1. Navigate to **_Settings > Developer Settings > Personal Access Tokens_**
-  !['PAT' page on GitHub](images/pat/pat-settings.png)
+  1. Click [this link](https://github.com/settings/tokens/new?scopes=repo&description=R:GITHUB_PAT) to take you to right Github settings page. Or else you can navigate there on the Github site by going to **_Settings > Developer Settings > Personal Access Tokens_**
   
   2. Select **_Generate new token_** and select the **scope** of access you want to grant using this token.
   
@@ -330,12 +329,12 @@ To generate your PAT for reading private repos in R:
 
 ### Using a PAT to authenticate in R/RStudio
 
-You should store your PAT in an R profile file in your *home directory* (on AP). This file gets run when you start R, putting the PAT into the system environment variable `GITHUB_PAT`. This is where common R packages (e.g. remotes and devtools) will look for it.
+You should store your PAT in a special R file, called .Renviron, in your *home directory* (on AP). This file gets run when you start R, putting the PAT into the system environment variable `GITHUB_PAT`. This is where common R packages (e.g. remotes, devtools and renv) will look for it.
 
 Set this up by running this in your R console (you only need to run it once; do **not** save this line in any file in any repo) and substitute your own PAT Token in place of the example PAT `ax451...8838b1` below:
   
 ```{r, eval = FALSE}
-writeLines('Sys.setenv("GITHUB_PAT" = "ax451...8838b1")', con = "~/.Rprofile")
+writeLines("GITHUB_PAT=ax451...8838b1", con = "~/.Renviron")
 ```
 
 **Warning: This line should not be put in any repo, and this .Rprofile file should not be added to any repo.**

--- a/source/documentation/github.md
+++ b/source/documentation/github.md
@@ -315,7 +315,7 @@ You can get a PAT from your GitHub user profile. A user can generate a number of
 
 To generate your PAT for reading private repos in R:
 
-  1. Click [this link](https://github.com/settings/tokens/new?scopes=repo&description=R:GITHUB_PAT) to take you to right Github settings page. Or else you can navigate there on the Github site by going to **_Settings > Developer Settings > Personal Access Tokens_**
+  1. Navigate to the [GitHub personal access tokens page](https://github.com/settings/tokens/new?scopes=repo&description=R:GITHUB_PAT). You can also access this from any other GitHub page by selecting your user icon, then **Settings**, then **Developer settings**, then **Personal access tokens**.
   
   2. Select **_Generate new token_** and select the **scope** of access you want to grant using this token.
   

--- a/source/documentation/github.md
+++ b/source/documentation/github.md
@@ -315,9 +315,9 @@ You can get a PAT from your GitHub user profile. A user can generate a number of
 
 To generate your PAT for reading private repos in R:
 
-  1. Navigate to the [GitHub personal access tokens page](https://github.com/settings/tokens/new?scopes=repo&description=R:GITHUB_PAT). You can also access this from any other GitHub page by selecting your user icon, then **Settings**, then **Developer settings**, then **Personal access tokens**.
+  1. Navigate to the [GitHub personal access tokens page](https://github.com/settings/tokens/new?scopes=repo&description=R:GITHUB_PAT). You can also access this from any other GitHub page by selecting your user icon, then **Settings**, then **Developer settings**, then **Personal access tokens**, and on that page select **_Generate new token_**.
   
-  2. Select **_Generate new token_** and select the **scope** of access you want to grant using this token.
+  2. Ensure that the **scope** of access you want to grant using this token is set only to 'repo'.
   
      **IMPORTANT: Only select the first group: 'repo'. Granting other rights can be dangerous if your PAT falls into the wrong hands, allowing someone else to irrevocably delete your repos, read and change your user profile settings, or even access billing information. If you need to to use other rights, consult with the AP team for advice on security arrangements to protect the PAT.**
   !['New PAT' page](images/pat/pat-scope.png)


### PR DESCRIPTION
This update does two things:
1. adds a direct link to the Github PAT generating page, which pre-defines the scope to be only repo, and makes it easier to find.
2. changes the code provided to write the PAT to the .Renviron file instead of the .Rprofile file, which appears to be the recommended way.  The previous method of writing to the .Rprofile file doesn't work for me on the R upgrade to v4. (See also section "Where to put what?" in https://rviews.rstudio.com/2017/04/19/r-for-enterprise-understanding-r-s-startup/