### PR TITLE
Data section updates and some minor other changes

### DIFF
--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -179,7 +179,7 @@ You can find out more about how to use these and other functions in the [Migrati
 
 #### `mojap-arrow-pd-parser`
 
-Snappily named `mojap-pd-arrow-parser` provides easy csv, jsonl and parquet file writers. To install in terminal:
+Snappily named `mojap-arrow-pd-parser` provides easy csv, jsonl and parquet file writers. To install in terminal:
 
 ```bash
 pip install arrow-pd-parser
@@ -192,7 +192,7 @@ from arrow_pd_parser import writer
 writer.write("s3://bucket_name/file.csv")
 ```
 
-`mojap-pd-arrow-parser` infers the file type from the extension, so for example `writer.write("s3://bucket_name/file.snappy.parquet")` would write a (snappy compressed) parquet file without need for specifying the file type.
+`mojap-arrow-pd-parser` infers the file type from the extension, so for example `writer.write("s3://bucket_name/file.snappy.parquet")` would write a (snappy compressed) parquet file without need for specifying the file type.
 
 The package also has a lot of other functionality including specifying data types when writing (or reading). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
 
@@ -312,7 +312,7 @@ You can find out more about how to use these and other functions in the [Migrati
 
 #### `mojap-arrow-pd-parser`
 
-`mojap-pd-arrow-parser` provides easy csv, jsonl and parquet file readers. To install in terminal:
+`mojap-arrow-pd-parser` provides easy csv, jsonl and parquet file readers. To install in terminal:
 
 ```bash
 pip install arrow-pd-parser
@@ -325,7 +325,7 @@ from arrow_pd_parser import reader
 reader.read("s3://bucket_name/file.csv")
 ```
 
-`mojap-pd-arrow-parser` infers the file type from the extension, so for example `reader.read("s3://bucket_name/file.parquet")` would read a parquet file without need for specifying the file type.
+`mojap-arrow-pd-parser` infers the file type from the extension, so for example `reader.read("s3://bucket_name/file.parquet")` would read a parquet file without need for specifying the file type.
 
 The package also has a lot of other functionality including specifying data types when reading (or writing). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
 

--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -194,7 +194,7 @@ writer.write("s3://bucket_name/file.csv")
 
 `mojap-pd-arrow-parser` infers the file type from the extension, so for example `writer.write("s3://bucket_name/file.snappy.parquet")` would write a (snappy compressed) parquet file without need for specifying the file type.
 
-The package also has a lot of other benefits in specifying data types when writing (or reading). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
+The package also has a lot of other functionality including specifying data types when writing (or reading). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
 
 #### `boto3`
 
@@ -327,7 +327,7 @@ reader.read("s3://bucket_name/file.csv")
 
 `mojap-pd-arrow-parser` infers the file type from the extension, so for example `reader.read("s3://bucket_name/file.parquet")` would read a parquet file without need for specifying the file type.
 
-The package also has a lot of other benefits in specifying data types when reading (or writing). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
+The package also has a lot of other functionality including specifying data types when reading (or writing). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
 
 #### `pandas`
 

--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -177,6 +177,27 @@ You can find out more about how to use these and other functions in the [Migrati
 
 ### JupyterLab
 
+#### `mojap-arrow-pd-parser`
+
+Snappily named `mojap-pd-arrow-parser` provides easy csv, jsonl and parquet file writers. To install in terminal:
+
+```bash
+pip install arrow-pd-parser
+```
+
+To write a csv file to s3:
+
+```python
+from arrow_pd_parser import writer
+writer.write("s3://bucket_name/file.csv")
+```
+
+`mojap-pd-arrow-parser` infers the file type from the extension, so for example `writer.write("s3://bucket_name/file.snappy.parquet")` would write a (snappy compressed) parquet file without need for specifying the file type.
+
+The package also has a lot of other benefits in specifying data types when writing (or reading). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
+
+#### `boto3`
+
 You can upload files in JupyterLab on the Analytical Platform to Amazon S3 using the `boto3` package.
 
 You can install `boto3` by running the following code in a terminal:
@@ -287,6 +308,26 @@ your_df <- s3_read(read.csv, "s3://your_bucket/your_key.csv")
 You can find out more about how to use these and other functions in the [Migrating to botor](../../appendix/botor.html#migrating-to-botor) appendix, the [botor documentation](https://daroczig.github.io/botor/reference/index.html) or by using the help operator in RStudio (for example, `?botor::s3_write`).
 
 ### JupyterLab
+
+
+#### `mojap-arrow-pd-parser`
+
+`mojap-pd-arrow-parser` provides easy csv, jsonl and parquet file readers. To install in terminal:
+
+```bash
+pip install arrow-pd-parser
+```
+
+To read a csv file from s3:
+
+```python
+from arrow_pd_parser import reader
+reader.read("s3://bucket_name/file.csv")
+```
+
+`mojap-pd-arrow-parser` infers the file type from the extension, so for example `reader.read("s3://bucket_name/file.parquet")` would read a parquet file without need for specifying the file type.
+
+The package also has a lot of other benefits in specifying data types when reading (or writing). More details can be found in the package [README](https://github.com/moj-analytical-services/mojap-arrow-pd-parser#mojap-arrow-pd-parser).
 
 #### `pandas`
 

--- a/source/documentation/data-docs/curated-databases-docs/databases.md
+++ b/source/documentation/data-docs/curated-databases-docs/databases.md
@@ -9,7 +9,7 @@ To see what databases are available and how to request access, see the [README](
 
 > Note, you must be a member of the [moj-analytical-services](https://github.com/moj-analytical-services) GitHub organisation to access the repository.
 
-To find out about the metadata of the curated databases (without making a database access request), you can use the [metadata search tool](#metadata-search-tool).
+To find out about the metadata of the curated databases (without making a database access request), you can use the [data discovery tool](../data-documentation).
 
 ## User-maintained databases
 

--- a/source/documentation/tools/jupyterlab.md
+++ b/source/documentation/tools/jupyterlab.md
@@ -25,27 +25,33 @@ cd myproject
 python3 myscript.py
 ```
 
-### Using a venv in Jupyter
+### Using a virtual environment in Jupyter
 
-Jupyter won't use your venv, and the packages installed into it, unless you do the following set-up:
+It is advisable to use a different virtual environment (venv) for each project you do in Python. There is a little bit of set up to get Jupyter working with a venv. Follow the instructions below to get started:
 
-1. In the terminal, activate your venv:
+0. If you haven't yet created a virtual environment for your project, in terminal run:
 
     ```bash
     cd myproject
+    python3 -m venv venv
+    ```
+
+1. In the terminal, inside your project directory, activate your venv:
+
+    ```bash
     source venv/bin/activate
     ```
 
 2. Install the module ipykernel within this venv (for creating/managing kernels for ipython which is what Jupyter sits on top of):
 
     ```bash
-    pip3 install ipykernel
+    pip install ipykernel
     ```
 
 3. Create a Jupyter kernel which is configured to use your venv. (Change the display name to match your project name):
 
     ```bash
-    python3 -m ipykernel install --user --name="venvname" --display-name="My project (Python3)"
+    python3 -m ipykernel install --user --name="venv" --display-name="My project (Python3)"
     ```
 
 4. In Jupyter, open your notebook and then select this new kernel by its pretty name in the top right hand corner. It might take a little time/refreshes for it to show up.
@@ -59,7 +65,7 @@ To resume work on this after working on another project:
     source venv/bin/activate
     ```
 
-    Now you've activated this terminal with your venv, things you run on the command-line will default to using your venv for python packages, rather than the system's packages. That's useful if you run 'python', run python scripts or 'pip install' more packages.
+    Now you've activated this terminal with your venv, things you run on the command-line will default to using your venv for python packages, rather than the system's packages. That's useful if you run 'python3', run python scripts or 'pip install' more packages.
 
 2. Open the notebook - it’s remembered which kernel you wanted to use for this notebook and you can carry on working with the packages available.
 

--- a/source/documentation/tools/package-management.md
+++ b/source/documentation/tools/package-management.md
@@ -347,20 +347,18 @@ When you work with your project's packages in a terminal, you'll want to 'activa
 
 You'll notice the prompt changes to show that the venv is activated: `(venv) jovyan@jupyter-lab-davidread-ju-6966d9b9b4-7zvsk:~/myproject$`
 
-With the venv activated you can install some packages using pip3:
+With the venv activated you can install some packages using pip:
 
 ```bash
-(venv) $ pip3 install pandas
+(venv) $ pip install pandas
 ```
-
-Tip: Use `pip3` instead of `pip`, because Analytical Platform has setup `pip` to always install to `~/.local/`. Bear with us while we fix this.
 
 The packages will get installed to your venv, in `venv/lib/python3.7/site-packages/`.
 
 You can see what packages are installed using 'pip freeze':
 
 ```bash
-(venv) $ pip3 freeze
+(venv) $ pip freeze
 numpy==1.18.4
 pandas==1.0.4
 python-dateutil==2.8.1
@@ -381,7 +379,7 @@ In JupyterLab, to be able to use the venv's packages (instead of the system pack
 When you commit your code, to ensure reproducibility, you should also commit an up-to-date record of what packages you've installed. The simplest way is to do:
 
 ```bash
-(venv) $ pip3 freeze >requirements.txt
+(venv) $ pip freeze >requirements.txt
 (venv) $ git add requirements.txt
 ```
 
@@ -404,4 +402,4 @@ Before you can run this project, you need some files setup in your home dir, usi
 
     # install the python packages required
     . venv/bin/activate
-    pip3 install -r requirements.txt
+    pip install -r requirements.txt


### PR DESCRIPTION
Addition:

- Accessing data from/to S3 via `mojap-arrow-pd-parser`

Changes:

- references to `pip3` now say `pip`. "Tip: Use `pip3` instead of `pip`, because Analytical Platform has setup `pip` to always install to `~/.local/`. Bear with us while we fix this." I don't think this is true anymore (it isn't on my account).
- Some old links changed
- Tried to make using a venv in jupyterlab a little clearer as I think it would be a bit tricky for a first time user