### PR TITLE
a fix for an athena issue some users have faced

### DIFF
--- a/source/documentation/data-docs/curated-databases-docs/amazon-athena.md
+++ b/source/documentation/data-docs/curated-databases-docs/amazon-athena.md
@@ -20,6 +20,18 @@ This will bring you to the Athena query editor. Here, you can:
 
 ![](images/curated-databases/access-athena-3.png)
 
+### Athena Access Issue
+
+Some users may find when first running a query in the Athena editor, that they get an error similar to:
+
+```
+Access denied when writing output to url: s3://<bucket_name>/<file_name.csv>. 
+Please ensure you are allowed to access the S3 bucket. 
+If you are encrypting query results with KMS key, please ensure you are allowed to access your KMS key
+```
+
+A fix for this error can be found [here](https://github.com/moj-analytical-services/user-guidance-internal/wiki/Athena-set-up-issue).
+
 ## Previewing tables
 
 In many cases, it may be useful to preview a table to get a better understanding of its structure and contents.


### PR DESCRIPTION
There is an issue a few users have faced when trying to use Athena where they can’t run queries in the editor. It seems to be fixed by adding a bucket name to the query result location. This covers that fix. I have linked to a new repo called [user-guidance-internal](https://github.com/moj-analytical-services/user-guidance-internal). The wiki can be used for anything we think should not be published on the public guidance.