### PR TITLE
Update documentation to enable review of documents

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -36,7 +36,7 @@ github_repo: moj-analytical-services/user-guidance
 
 # Slack options
 owner_slack_workspace: asdslack
-default_owner_slack: '#analytical_platform'
+default_owner_slack: '#analytical-platform-support'
 
 footer_links:
   Get in touch by email: mailto:analytical_platform@digital.justice.gov.uk

--- a/source/about.html.md.erb
+++ b/source/about.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: About the Analytical Platform
 weight: 30
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/about' %>

--- a/source/annexes.html.md.erb
+++ b/source/annexes.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Annexes
 weight: 140
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/annexes' %>

--- a/source/appendix/botor.html.md.erb
+++ b/source/appendix/botor.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Botor
 weight: 500
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/appendix-docs/botor' %>

--- a/source/appendix/dash.html.md.erb
+++ b/source/appendix/dash.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Dash
 weight: 170
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/appendix-docs/dash' %>

--- a/source/appendix/index.html.md.erb
+++ b/source/appendix/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Appendix
 weight: 150
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/appendix-docs/index' %>

--- a/source/aup.html.md.erb
+++ b/source/aup.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Acceptable use policy
 weight: 100
+last_reviewed_on: 2022-05-13
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/aup' %>

--- a/source/build-deploy.html.md.erb
+++ b/source/build-deploy.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Build and deploy
 weight: 80
+last_reviewed_on: 2022-05-01
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/build-deploy' %>

--- a/source/data/amazon-s3/index.html.md.erb
+++ b/source/data/amazon-s3/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Amazon S3
 weight: 50
+last_reviewed_on: 2022-05-01
+review_in: 1 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/data-docs/amazon-s3' %>

--- a/source/data/home-directories/index.html.md.erb
+++ b/source/data/home-directories/index.html.md.erb
@@ -2,8 +2,9 @@
 title: Home Directories
 weight: 48
 last_reviewed_on: 2022-02-02
-review_in: 1 year
+review_in: 3 months
 show_expiry: true
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/data-docs/home-directories' %>

--- a/source/data/index.html.md.erb
+++ b/source/data/index.html.md.erb
@@ -2,8 +2,9 @@
 title: Data
 weight: 40
 last_reviewed_on: 2021-08-01
-review_in: 1 year
 show_expiry: true
+review_in: 11 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/data-docs/index' %>

--- a/source/documentation/appendix-docs/dash.md
+++ b/source/documentation/appendix-docs/dash.md
@@ -1,6 +1,6 @@
 # Running your app within Jupyter
 
-It is likely that you will want to preview and test your app before you deploy it. 
+It is likely that you will want to preview and test your app before you deploy it.
 However because of security implications we cannot allow arbritrary ports to be opened.
 Instead, you have to use the `/\_tunnel\_/` endpoint we have provided.
 
@@ -147,7 +147,7 @@ team. It is intended for testing while developing an application.
 
 This feature has been introduced in the v0.6.5 jupyer-lab helm chart. If following
 this guide doesn't work for you it is likely that you're on an older version.
-Contact us on the `#analytical_platform` [Slack channel],
+Contact us on the `#analytical-platform` [Slack channel],
 alternatively, contact us by [email](mailto:analytical_platform@digital.justice.gov.uk)
 to request an upgrade.
 

--- a/source/errors.html.md.erb
+++ b/source/errors.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Common Errors and Solutions
 weight: 130
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/errors' %>

--- a/source/get-started.html.md.erb
+++ b/source/get-started.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Get Started
 weight: 25
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/get-started' %>

--- a/source/github.html.md.erb
+++ b/source/github.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Using GitHub with the platform
 weight: 50
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/github' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Introduction
 weight: 20
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/index' %>

--- a/source/information-governance.html.md.erb
+++ b/source/information-governance.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Information governance
 weight: 110
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/information-governance' %>

--- a/source/parameters.html.md.erb
+++ b/source/parameters.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Parameters
 weight: 100
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/parameters' %>

--- a/source/rshiny-app.html.md.erb
+++ b/source/rshiny-app.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Deploy an RShiny app
 weight: 60
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/rshiny-app' %>

--- a/source/static-app.html.md.erb
+++ b/source/static-app.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Deploy a static web app
 weight: 70
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/static-app' %>

--- a/source/support.html.md.erb
+++ b/source/support.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: How to get support
 weight: 120
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/support' %>

--- a/source/tools/airflow.html.md.erb
+++ b/source/tools/airflow.html.md.erb
@@ -1,6 +1,9 @@
 ---
 title: Airflow
 weight: 3
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/airflow' %>

--- a/source/tools/index.html.md.erb
+++ b/source/tools/index.html.md.erb
@@ -1,9 +1,10 @@
 ---
 title: Tools
 weight: 50
-last_reviewed_on: 2021-02-03
+last_reviewed_on: 2021-06-03
 review_in: 1 year
 show_expiry: true
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/index' %>

--- a/source/tools/jupyterlab.html.erb
+++ b/source/tools/jupyterlab.html.erb
@@ -1,6 +1,9 @@
 ---
 title: JupyterLab
 weight: 2
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/jupyterlab' %>

--- a/source/tools/package-management.html.md.erb
+++ b/source/tools/package-management.html.md.erb
@@ -2,6 +2,9 @@
 title: Package Management
 weight: 34
 tags: rstudio, jupyterlab
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/package-management' %>

--- a/source/tools/rstudio.html.erb
+++ b/source/tools/rstudio.html.erb
@@ -2,6 +2,9 @@
 title: RStudio
 weight: 1
 tags: rstudio
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/rstudio' %>

--- a/source/tools/upgrading.html.md.erb
+++ b/source/tools/upgrading.html.md.erb
@@ -2,6 +2,9 @@
 title: Upgrading RStudio
 weight: 6
 published: false
+last_reviewed_on: 2022-05-01
+review_in: 2 months
+owner_slack: "#analytical-platform"
 ---
 
 <%= partial 'documentation/tools/upgrading' %>


### PR DESCRIPTION
Hi 👋 I'm a developer on the #analytical-platform.

This is a partial work to enable being notified on our slack channel 
about which documents may be out of date.

This will be monitored by the [tech-docs-monitor](https://github.com/ministryofjustice/tech-docs-monitor) automatically and generates an alert on the slack channel #analytical-platform so that we are aware of possible changes.

Each file will be reviewed accordingly and if we do find a need to change ownership along the way it will be done on an individual basis.