### PR TITLE
Update owner_slack_workspace property to mojdt

### DIFF
--- a/source/about.html.md.erb
+++ b/source/about.html.md.erb
@@ -4,6 +4,7 @@ weight: 30
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/about' %>

--- a/source/annexes.html.md.erb
+++ b/source/annexes.html.md.erb
@@ -4,6 +4,7 @@ weight: 140
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/annexes' %>

--- a/source/appendix/botor.html.md.erb
+++ b/source/appendix/botor.html.md.erb
@@ -4,6 +4,7 @@ weight: 500
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/appendix-docs/botor' %>

--- a/source/appendix/dash.html.md.erb
+++ b/source/appendix/dash.html.md.erb
@@ -4,6 +4,7 @@ weight: 170
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/appendix-docs/dash' %>

--- a/source/appendix/index.html.md.erb
+++ b/source/appendix/index.html.md.erb
@@ -4,6 +4,7 @@ weight: 150
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/appendix-docs/index' %>

--- a/source/aup.html.md.erb
+++ b/source/aup.html.md.erb
@@ -4,6 +4,7 @@ weight: 100
 last_reviewed_on: 2022-05-13
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/aup' %>

--- a/source/build-deploy.html.md.erb
+++ b/source/build-deploy.html.md.erb
@@ -4,6 +4,7 @@ weight: 80
 last_reviewed_on: 2022-05-01
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/build-deploy' %>

--- a/source/data/amazon-s3/index.html.md.erb
+++ b/source/data/amazon-s3/index.html.md.erb
@@ -4,6 +4,7 @@ weight: 50
 last_reviewed_on: 2022-05-01
 review_in: 1 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/data-docs/amazon-s3' %>

--- a/source/data/home-directories/index.html.md.erb
+++ b/source/data/home-directories/index.html.md.erb
@@ -5,6 +5,7 @@ last_reviewed_on: 2022-02-02
 review_in: 3 months
 show_expiry: true
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/data-docs/home-directories' %>

--- a/source/data/index.html.md.erb
+++ b/source/data/index.html.md.erb
@@ -5,6 +5,7 @@ last_reviewed_on: 2021-08-01
 show_expiry: true
 review_in: 11 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/data-docs/index' %>

--- a/source/errors.html.md.erb
+++ b/source/errors.html.md.erb
@@ -4,6 +4,7 @@ weight: 130
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/errors' %>

--- a/source/get-started.html.md.erb
+++ b/source/get-started.html.md.erb
@@ -4,6 +4,7 @@ weight: 25
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/get-started' %>

--- a/source/github.html.md.erb
+++ b/source/github.html.md.erb
@@ -4,6 +4,7 @@ weight: 50
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/github' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,6 +4,7 @@ weight: 20
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/index' %>

--- a/source/information-governance.html.md.erb
+++ b/source/information-governance.html.md.erb
@@ -4,6 +4,7 @@ weight: 110
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/information-governance' %>

--- a/source/parameters.html.md.erb
+++ b/source/parameters.html.md.erb
@@ -4,6 +4,7 @@ weight: 100
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/parameters' %>

--- a/source/rshiny-app.html.md.erb
+++ b/source/rshiny-app.html.md.erb
@@ -4,6 +4,7 @@ weight: 60
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/rshiny-app' %>

--- a/source/static-app.html.md.erb
+++ b/source/static-app.html.md.erb
@@ -4,6 +4,7 @@ weight: 70
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/static-app' %>

--- a/source/support.html.md.erb
+++ b/source/support.html.md.erb
@@ -4,6 +4,7 @@ weight: 120
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/support' %>

--- a/source/tools/airflow.html.md.erb
+++ b/source/tools/airflow.html.md.erb
@@ -4,6 +4,7 @@ weight: 3
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/airflow' %>

--- a/source/tools/index.html.md.erb
+++ b/source/tools/index.html.md.erb
@@ -5,6 +5,7 @@ last_reviewed_on: 2021-06-03
 review_in: 1 year
 show_expiry: true
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/index' %>

--- a/source/tools/jupyterlab.html.erb
+++ b/source/tools/jupyterlab.html.erb
@@ -4,6 +4,7 @@ weight: 2
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/jupyterlab' %>

--- a/source/tools/package-management.html.md.erb
+++ b/source/tools/package-management.html.md.erb
@@ -5,6 +5,7 @@ tags: rstudio, jupyterlab
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/package-management' %>

--- a/source/tools/rstudio.html.erb
+++ b/source/tools/rstudio.html.erb
@@ -5,6 +5,7 @@ tags: rstudio
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/rstudio' %>

--- a/source/tools/upgrading.html.md.erb
+++ b/source/tools/upgrading.html.md.erb
@@ -5,6 +5,7 @@ published: false
 last_reviewed_on: 2022-05-01
 review_in: 2 months
 owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
 ---
 
 <%= partial 'documentation/tools/upgrading' %>


### PR DESCRIPTION
We have two slack accounts, one to support the analyst community and one for the tech team. 

This PR aims to set the workspace of individual documents to the correct workspace for the #analytical-platform channel (mojdt).