### PR TITLE
Add delete argument to aws-s3/sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - attach_workspace:
           at: ~/project/docs/
       - aws-s3/sync:
+          arguments: '--delete'
           from: ~/project/docs
           to: "s3://user-guidance.analytical-platform.services.justice.gov.uk"
 


### PR DESCRIPTION
Add delete argument to aws-s3/sync so old files are deleted and don't show up in searches or outdated bookmarks.