### PR TITLE
Gave create a derived table its own page

### DIFF
--- a/source/documentation/tools/create-a-derived-table/index.md
+++ b/source/documentation/tools/create-a-derived-table/index.md
@@ -1,0 +1,5 @@
+# Create a Derived Table
+
+This services lets you use SQL to transform raw data into persistent derived tables. Using a tool called dbt, you can make consistent, replicable tables without touching R or Python, and have them regularly updated without touching Airflow. You can also test your transformations and break down complex SQL into reusable modular queries.
+
+We're in the early stages of developing the service. Visit the [Create a Derived Table repo](https://github.com/moj-analytical-services/create-a-derived-table) to see progress, or ask us about testing on the [#ask-data-modelling](https://asdslack.slack.com/archives/C03J21VFHQ9) Slack channel.

--- a/source/documentation/tools/index.md
+++ b/source/documentation/tools/index.md
@@ -19,8 +19,8 @@ The data engineering team maintain a number of databases on the Analytical Platf
 ### Data Uploader
 Under construction
 
-### Create a Derived Table
-Implements a tool called dbt, for creating persistent derived tables in Athena. Visit the [Create a Derived Table repo](https://github.com/moj-analytical-services/create-a-derived-table) to see progress, or sign up for testing on the [#ask-data-modelling](https://asdslack.slack.com/archives/C03J21VFHQ9) Slack channel.
+### [Create a Derived Table](create-a-derived-table)
+A tool for creating persistent derived tables in Athena
 
 ### Python packages
 

--- a/source/tools/create-a-derived-table/index.html.md.erb
+++ b/source/tools/create-a-derived-table/index.html.md.erb
@@ -1,0 +1,11 @@
+---
+title: Create a Derived Table
+weight: 60
+last_reviewed_on: 2022-07-13
+review_in: 1 year
+show_expiry: true
+owner_slack: "#ask-data-modelling"
+owner_slack_workspace: "mojdt"
+---
+
+<%= partial 'documentation/tools/create-a-derived-table/index' %>


### PR DESCRIPTION
This creates a short page on Create a Derived Table, in the tools section. The page is mainly links to the repo and Slack channel. It's in the left-hand navigation, so it's more visible if people are looking for it. 