### PR TITLE
Advise users not to leave an empty new line in the S3 path text area

### DIFF
--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -52,14 +52,14 @@ Every bucket has three data access levels:
 
 ### Path specific access
 
-As well as choosing an access level, you can also restrict a user's access to specific paths in a bucket by entering each path on a new line in the 'Paths' textarea field when adding the user to a data access group. For example:
+As well as choosing an access level, you can also restrict a user's access to specific paths in a bucket by entering each path on a new line in the 'Paths' textarea field when adding the user to a data access group, taking care not to leave an empty new line after the last path. For example:
 
     /folder-one
     /folder-two
 
-This would give the user access to only `/folder-one` and `/folder-two` in the bucket and nothing else.
+This would give the user access to only `/folder-one` and `/folder-two` in the bucket and nothing else. 
 
-If you leave this field blank, the user will be able to access everything in the bucket.
+If you leave this field blank, the user will be able to access everything in the bucket. 
 
 ### Request access to a bucket
 


### PR DESCRIPTION
If a user leaves a blank new line in the text area used to add subfolder paths to an S3 access list when granting permissions to one of their warehouse buckets, this seems to cause an error. Add a sentence to explicitly state not to do this. 

`https://user-guidance.services.alpha.mojanalytics.xyz/data/amazon-s3/#path-specific-access`