### PR TITLE
Pin nokogiri version independently of dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 
+# Nokogiri so that we can update it separately from the tech docs gem
+gem 'nokogiri', '~> 1.13.9'
+
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     multi_json (1.15.0)
-    nokogiri (1.13.6)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
@@ -179,9 +179,10 @@ PLATFORMS
 
 DEPENDENCIES
   govuk_tech_docs!
+  nokogiri (~> 1.13.9)
   tzinfo-data
   wdm (~> 0.1.0)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.8
+   2.3.0


### PR DESCRIPTION
Various gems use nokogiri with various version constraints, but it is often the target of various CVEs.  This PR pins our nokogiri to a specific version that we can manage as more CVEs are discovered.

Currently tech docs requires any version of nokogiri and so we ended up with an earlier version from another dependency. 