### PR TITLE
Pin commonmarker gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 # Windows does not come with time zone data
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
+# Pin commonmarker until openapi_parser releases a new version
+# See https://github.com/kevindew/openapi3_parser/issues/25#issuecomment-1279064796
+gem 'commonmarker', "~> 0.23.6"
+
 # Include the tech docs gem
 gem 'govuk_tech_docs', git: 'https://github.com/moj-analytical-services/tech-docs-gem'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    commonmarker (0.23.4)
+    commonmarker (0.23.6)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -178,10 +178,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  commonmarker (~> 0.23.6)
   govuk_tech_docs!
   tzinfo-data
   wdm (~> 0.1.0)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.8
+   2.3.0


### PR DESCRIPTION
The commonmarker gem shipped as part of openapi_parser is out of date, and although that has been fixed it won't be shipped soon (https://github.com/kevindew/openapi3_parser/issues/25#issuecomment-1279064796).

This PR pins commonmarker at a currently safe version.