### PR TITLE
:memo: Add user guide to site header

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,7 +3,7 @@ host: https://user-guidance.services.alpha.mojanalytics.xyz
 
 # Header-related options
 show_govuk_logo: false
-service_name: MoJ Analytical Platform
+service_name: Analytical Platform User Guide
 service_link: https://user-guidance.services.alpha.mojanalytics.xyz
 phase:
 


### PR DESCRIPTION
This PR adds User Guide to header for clarity and clearly named bookmarks
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/20583399/220078587-dbcdaa9f-8198-4d5e-b90e-aa7ab4d7910a.png">
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/20583399/220078647-123a4578-d559-4bd0-bd14-40737e2ed0e0.png">
