### PR TITLE
Fix example code in package-management.md

### DIFF
--- a/source/documentation/tools/rstudio/package-management.md
+++ b/source/documentation/tools/rstudio/package-management.md
@@ -46,7 +46,7 @@ Basic commands to follow to install packages for renv are:
 
 ```r
 # install renv (if not already installed)
-install.packages(“renv”)
+install.packages("renv")
 
 # If you are starting a fresh repository, run this:
 renv::init(bare = TRUE)


### PR DESCRIPTION
One line of code used a non-standard type of quotation mark (`"`), which would cause an error message for users who copied and pasted the code from this guidance.