### PR TITLE
Clarify bucket access request process

### DIFF
--- a/source/documentation/data-docs/amazon-s3.md
+++ b/source/documentation/data-docs/amazon-s3.md
@@ -67,7 +67,9 @@ To gain access to a bucket (warehouse data source or webapp data source), you mu
 
 If you know an admin of the bucket you require access to, you should ask them to add you to the data access group.
 
-If you do not know any of the admins of the bucket you require access to, you can ask the Analytical Platform team to add you to the data access group on the [#analytical-platform-support](https://app.slack.com/client/T02DYEB3A/C4PF7QAJZ) Slack channel or by email ([analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk)).
+If you do not know any of the admins of the bucket you require access to, you can find a list of the GitHub usernames of all bucket admins on the Warehouse Data page of Control Panel (scroll down the page), or contact the Analytical Platform team via [Slack](https://app.slack.com/client/T02DYEB3A/C4PF7QAJZ), [GitHub](https://github.com/ministryofjustice/data-platform-support/issues/new/choose) or email ([analytical_platform@digital.justice.gov.uk](mailto:analytical_platform@digital.justice.gov.uk)).
+
+If all bucket admins are unavailable (e.g. have left the MoJ), the  Analytical Platform team will be able to grant you access to the datasource if the request is approved by your line manager.
 
 When requesting access to a bucket, you should specify the name of the bucket and the level of access you require. You should only request access to data that you have a genuine business need to access and should only request the lowest level of access required for you to complete your work. You may be required to demonstrate the business need for you to access a bucket if requested by a bucket admin or an information asset owner (IAO).
 

--- a/source/documentation/data-docs/data-faqs/index.md
+++ b/source/documentation/data-docs/data-faqs/index.md
@@ -10,7 +10,7 @@ In addition to this users can create their own S3 buckets which may have data us
 
 Access to curated databases is granted via the [database access repository](https://github.com/moj-analytical-services/data-engineering-database-access). Have a read through the guidance on there. If you are finding the process a little tricky, please ask for help in `#ask-data-engineering`. A data engineer will happily guide you through things.
 
-If you are looking for access to a user created bucket, then the admin of that bucket should be able to grant you access. If you don't know who the admin is, or they are not able to grant you access, then ask in the [#analytical-platform-support](https://app.slack.com/client/T02DYEB3A/C4PF7QAJZ) Slack channel.
+If you are looking for access to a user created bucket, then the admin of that bucket should be able to grant you access. If you don't know who the admin is, or they are not able to grant you access, then ask in the [#analytical-platform-support](https://app.slack.com/client/T02DYEB3A/C4PF7QAJZ) Slack channel or via [GitHub](https://github.com/ministryofjustice/data-platform-support/issues/new/choose). If the bucket admin is unavailable, the Analytical Platform team will need to receive approval from your line manager before you can be given any access to the bucket.
 
 ## Where should I store my own data?
 


### PR DESCRIPTION
For cases where no bucket admin is available, explain that access requests will only be granted by the AP team if the user has approval from their line manager (as decided in Data Ownership on the AP meeting).