### PR TITLE
👥 Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/source/ @moj-analytical-services/user-guidance-editors
+/source/ @moj-analytical-services/user-guidance-editors @moj-analytical-services/analytical-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/source/ @moj-analytical-services/user-guidance-editors


### PR DESCRIPTION
This PR adds a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file and adds `editors group` and the `AP team` as owners of the /source directory. This was discussed [here](https://mojdt.slack.com/archives/C04BBJR3RPB/p1686306940916009)