### PR TITLE
DMT-312: Updating compatible Python versions 

### DIFF
--- a/source/documentation/tools/create-a-derived-table/instructions.md
+++ b/source/documentation/tools/create-a-derived-table/instructions.md
@@ -191,6 +191,7 @@ git clone git@github.com:moj-analytical-services/create-a-derived-table.git
 ```
 
 ## Setting up a Python virtual environment
+
 Python versions 3.7, 3.8, 3.9, 3.10 and 3.11 are compatible with dbt-core v1.5.0.
 
 In the terminal, `cd` into the root of the repository (`create-a-derived-table`). You can check you're in the correct directory by runnnig `pwd`. Once you've done that run:

--- a/source/documentation/tools/create-a-derived-table/instructions.md
+++ b/source/documentation/tools/create-a-derived-table/instructions.md
@@ -191,6 +191,7 @@ git clone git@github.com:moj-analytical-services/create-a-derived-table.git
 ```
 
 ## Setting up a Python virtual environment
+Python versions 3.7, 3.8, 3.9, 3.10 and 3.11 are compatible with dbt-core v1.5.0.
 
 In the terminal, `cd` into the root of the repository (`create-a-derived-table`). You can check you're in the correct directory by runnnig `pwd`. Once you've done that run:
 


### PR DESCRIPTION
#312 

Previously Python v3.11 was not compatible with dbt-core 1.3.0. With the upgrade to the dbt-athena-community adapter and dbt-core 1.5.0, Python v3.11 is now compatible. Adding one-liner about compatible Python versions with dbt-core v1.5.