### PR TITLE
📈 Update Google Analytics to GA4

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,7 +15,7 @@ header_links:
 enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: UA-151666116-1
+ga_tracking_id: G-M0RD516WGR
 
 # Enable multipage navigation in the sidebar
 multipage_nav: true


### PR DESCRIPTION
Universal Analytics has been killed off, this replaces the tracking tag with it's GA4 replacement

Caveat here is that this old version of tech-docs might not support it