### PR TITLE
add WAF steps to user documentation

### DIFF
--- a/source/documentation/apps/rshiny-app.md
+++ b/source/documentation/apps/rshiny-app.md
@@ -693,3 +693,21 @@ A complete example for installing the helm chart in the workflow below. These ch
 ```
 
 A full working example is available [here](https://github.com/ministryofjustice/ap-rshiny-notesbook)
+
+#### Enabling Web Application Firewall (WAF) for Data Platform Apps 
+
+There are two flags that need to be set to enable WAF for your application, Ingress.ModSec.enabled and GithubTeam
+
+To do this by adding the following lines in to your app's  `build-push-deploy-dev.yml` and `build-push-deploy-prod.yml` GitHub action workflow files:
+
+To change the resources insert at  the end of the file just before the $custom_variables the following as appropriate, remembering to use the line
+continuation “\” on the existing last line.
+
+> --set Ingress.ModSec.enabled="true"
+> --set GithubTeam="your github team"
+
+The changes  will be will be applied to your Kubernetes namespace following a push/merge to the repository and the running of the workflow
+
+To disable 
+
+> --set Ingress.ModSec.enabled="false"

--- a/source/documentation/apps/rshiny-app.md
+++ b/source/documentation/apps/rshiny-app.md
@@ -703,8 +703,13 @@ To do this by adding the following lines in to your app's  `build-push-deploy-de
 To change the resources insert at  the end of the file just before the $custom_variables the following as appropriate, remembering to use the line
 continuation “\” on the existing last line.
 
-> --set Ingress.ModSec.enabled="true"
-> --set GithubTeam="your github team"
+```
+ --set WebApp.Image.Tag=$NEW_TAG_V \
+ --set WebApp.Name=$KUBE_NAMESPACE \
+ --set Ingress.ModSec.enabled="true" \
+ --set GithubTeam="your github team" \
+$custom_variables
+```
 
 The changes  will be will be applied to your Kubernetes namespace following a push/merge to the repository and the running of the workflow
 

--- a/source/documentation/apps/rshiny-app.md
+++ b/source/documentation/apps/rshiny-app.md
@@ -698,10 +698,7 @@ A full working example is available [here](https://github.com/ministryofjustice/
 
 There are two flags that need to be set to enable WAF for your application, Ingress.ModSec.enabled and GithubTeam
 
-To do this by adding the following lines in to your app's  `build-push-deploy-dev.yml` and `build-push-deploy-prod.yml` GitHub action workflow files:
-
-To change the resources insert at  the end of the file just before the $custom_variables the following as appropriate, remembering to use the line
-continuation “\” on the existing last line.
+To do this modify your app's  `build-push-deploy-dev.yml` and `build-push-deploy-prod.yml` GitHub action workflow files as follows:
 
 ```
  --set WebApp.Image.Tag=$NEW_TAG_V \


### PR DESCRIPTION
Amend user documentation to add steps for implementing WAF to an application, for work carried out in issue [#1929](https://github.com/ministryofjustice/data-platform/issues/1929)