### PR TITLE
Update package-management.md with renv activate issue fix

### DIFF
--- a/source/documentation/tools/rstudio/package-management.md
+++ b/source/documentation/tools/rstudio/package-management.md
@@ -141,6 +141,7 @@ renv::use_python()
 |     Upgrade all packages to latest    |   Run `renv::update()` or `renv::update("packagename")` for specific package. Always check that upgrading packages does not break your code before pushing to github for other users. |
 |     Update renv itself    |     `renv::upgrade()`. Useful if renv gains new functionality that you want to use.    |
 |     _Error in file(filename, "r", encoding = encoding) : cannot open the connection_    |     Oops, you've accidentally installed renv in your home directory 🏠 ! Delete [all of the files created by renv](https://rstudio.github.io/renv/articles/renv.html#infrastructure) from your home directory and retry.    |
+|     _cannot open file 'renv/activate.R': No such file or directory_    |     Renv was installed incorrectly in the project. If you go to Tools > Project Options > Environments and tick use renv with this project that will force it to install renv, which will hopefully fix the problems.    |
 <div style="height:0px;font-size:0px;">&nbsp;</div>
 
 ## Conda


### PR DESCRIPTION
Adding the fix for the common issue where a broken renv installation prevents the installation of packages, including itself, which creates a chicken and egg problem that prevents you from fixing the broken installation.

RStudio knows how to force install renv, so the solution is to tell it to do that.