### PR TITLE
Bugfix/register apps

### DIFF
--- a/source/apps/alerting.html.md.erb
+++ b/source/apps/alerting.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Alerting on an app
-weight: 55
+weight: 80
 last_reviewed_on: 2023-10-19
 review_in: 12 months
 owner_slack: "#analytical-platform-support"

--- a/source/apps/index.html.md.erb
+++ b/source/apps/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Apps
 weight: 60
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2024-03-19
 review_in: 12 months
 owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"

--- a/source/apps/manage-app-settings-from-cpanel.html.md.erb
+++ b/source/apps/manage-app-settings-from-cpanel.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Manage deployment settings of an app on Control Panel
-weight: 65
-last_reviewed_on: 2023-06-02
+weight: 75
+last_reviewed_on: 2024-04-19
 review_in: 4 months
 owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"

--- a/source/apps/rshiny-app.html.md.erb
+++ b/source/apps/rshiny-app.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy an RShiny app
 weight: 65
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2023-04-19
 review_in: 12 months
 owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"

--- a/source/apps/static-app.html.md.erb
+++ b/source/apps/static-app.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Deploy a static web app
-weight: 70
-last_reviewed_on: 2023-01-30
+weight: 60
+last_reviewed_on: 2024-03-19
 review_in: 12 months
 owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"

--- a/source/apps/static-app.html.md.erb
+++ b/source/apps/static-app.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Deploy a static web app
+title: Deploy a Webapp
 weight: 60
 last_reviewed_on: 2024-03-19
 review_in: 12 months

--- a/source/apps/static-app.html.md.erb
+++ b/source/apps/static-app.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Deploy a Webapp
-weight: 60
+weight: 70
 last_reviewed_on: 2024-03-19
 review_in: 12 months
 owner_slack: "#analytical-platform-support"

--- a/source/documentation/apps/index.md
+++ b/source/documentation/apps/index.md
@@ -1,7 +1,7 @@
 # Apps
 
 Once you've built your app, you can make it available to users through the Analytical Platform.
-We have guidance for Shiny apps and static apps:
+We have guidance for:
 
 - Deploying your app
 - Accessing your deployed app

--- a/source/documentation/apps/index.md
+++ b/source/documentation/apps/index.md
@@ -9,11 +9,3 @@ We have guidance for Shiny apps and static apps:
 - Managing and Monitoring Deployments
 
 as well as common issues faced during these stages of publishing your app.
-
-> **&#x26a0;&#xfe0f; Note on deployment &#x26a0;&#xfe0f;**
-
-> It is not currently possible to deploy new apps on the Analytical Platform, though we are working to make this functionality available again as soon as possible.
-
-> In the meantime, you can still [access](#access-the-app) and [manage](#manage-app-users) existing apps.
-
-> If you have an existing app that requires urgent redeployment, please submit a [request](https://github.com/moj-analytical-services/analytical-platform-applications/issues/new?assignees=EO510%2C+YvanMOJdigital&labels=redeploy&template=redeploy-app-request.md&title=%5BREDEPLOY%5D) via GitHub. We normally redeploy apps each Wednesday, where we have recevied a request by the Friday before.

--- a/source/documentation/apps/rshiny-app.md
+++ b/source/documentation/apps/rshiny-app.md
@@ -7,6 +7,7 @@ We have guidance for:
 - [Accessing your deployed app](#accessing-the-deployed-app)
 - [Managing your app users](#manage-app-users)
 - [Managing and Monitoring Deployments](#managing-and-monitoring-deployments)
+- [Using Shiny Server](#shiny-server)
 
 as well as common issues faced during these stages of publishing your app.
 
@@ -14,7 +15,7 @@ as well as common issues faced during these stages of publishing your app.
 
 ### New apps
 
-Please follow the steps in in the [Deploying a Static Webapp section](/apps/static-app.html)
+Please follow the steps in in the [Deploying a Webapp section](/apps/static-app.html)
 
 ### Existing apps
 

--- a/source/documentation/apps/rshiny-app.md
+++ b/source/documentation/apps/rshiny-app.md
@@ -10,20 +10,11 @@ We have guidance for:
 
 as well as common issues faced during these stages of publishing your app.
 
-> **&#x26a0;&#xfe0f; Note on deployment &#x26a0;&#xfe0f;**
-
-> It is not currently possible to deploy new apps on the Analytical Platform, though we are working to make this functionality available again as soon as possible.
-
-> In the meantime, you can still [access](#access-the-app) and [manage](#manage-app-users) existing apps.
-
-> If you have an existing app that requires urgent redeployment, please submit a [request](https://github.com/moj-analytical-services/analytical-platform-applications/issues/new?assignees=EO510%2C+YvanMOJdigital&labels=redeploy&template=redeploy-app-request.md&title=%5BREDEPLOY%5D) via GitHub.
-> We normally redeploy apps each Wednesday, where we have recevied a request by the Friday before.
-
 ## App deployment
 
 ### New apps
 
-It is not currently possible to deploy new apps on the Analytical Platform, though we are working to make this functionality available again as soon as possible.
+Please follow the steps in in the [Deploying a Static Webapp section](/apps/static-app.html)
 
 ### Existing apps
 
@@ -600,7 +591,7 @@ This behaviour can result in:
 
 It also provides more [configuration options as outlined here](https://docs.posit.co/shiny-server/).
 
-> [!NOTE]
+> **NOTE:**
 > Options marked as "pro" are not available
 
 ### Instructions for using the open source shiny server image

--- a/source/documentation/apps/static-app.md
+++ b/source/documentation/apps/static-app.md
@@ -81,7 +81,7 @@ Repeat the following process for each of the environments (`dev`, `prod`) that y
 
 You can follow the instructions for each step individually, with a pull request for each, or complete all steps and include all the files in a single pull request.
 
-> [!NOTE]
+> **NOTE:**
 > Wait for CI checks to pass before requesting a review on your pull requests.
 > Request a review by sending a message including a link to your PR in the `#ask-cloud-platform` slack channel.
 
@@ -118,7 +118,7 @@ In addition, you will need to update the generated `01-rbac.yaml` file in your n
 
 [Follow the instructions in the Cloud Platform user guidance to add a container repository](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#adding-a-container-repository-to-your-namespace).
 
-> [!IMPORTANT]
+> **IMPORTANT:**
 > Amend the created `ecr.tf` file to add the following settings.
 
 1. `github_repositories` should include the name of your repository e.g. `github_repositories = ["<repo-name>]
@@ -216,21 +216,21 @@ You can see a [full example of a namespace directory](https://github.com/ministr
 
 ## Register the Application in Control Panel
 
-> [!IMPORTANT]
+> **IMPORTANT:**
 > You will need to have setup your GitHub repository to complete ths step
 
 1. Login to the [Control Panel](https://controlpanel.services.analytical-platform.service.justice.gov.uk)
 1. Click the "Webapps" link in the main navigation, and click the "Register app" button at the bottom of the page
 1. Enter the full URL of your GitHub repository
 1. Choose to create a new webapp data source (S3 bucket), connect an existing data source, or choose to do this later.
-> [!NOTE]
+> **NOTE:**
 > If you choose "Do this later" you will be able to create a Webapp data source by clicking the "Webapp data" button in the main navigation after registering your app. You will then need to come back to the "Manage app" page to link it to your Application.
 
 ### Manage the Application
 
 After registering the Application, you will be redirected to the "Manage app" page where you will find details about your app and can update deployment settings.
 
-> [!IMPORTANT]
+> **IMPORTANT:**
 > Any settings changes made via the "Manage app" page in Control Panel require the application to be redeployed before coming into effect
 
 You will need to create an Auth0 client to handle authentication for each environment that you setup.
@@ -251,7 +251,7 @@ The `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET` that have been added will be use
 
 To grant access to someone, in the [Control Panel wepapps tab](https://controlpanel.services.analytical-platform.service.justice.gov.uk/webapps) find your App and click "Manage App". In the 'App customers' section you can let people view your app by putting one or more email addresses in the text box and clicking "Add customer".
 
-> [!IMPORTANT]
+> **IMPORTANT:**
 > The "Manage Customers" page is only applicable to apps that use the "email" authentication process for login, which is enabled by default.
 
 ## Accessing the Application
@@ -259,7 +259,8 @@ To grant access to someone, in the [Control Panel wepapps tab](https://controlpa
 URLs for respective environments are as follows:
 - Development: `<repository-name>-dev.apps.live.cloud-platform.service.justice.gov.uk`.
 - Production: `<repository-name>.apps.live.cloud-platform.service.justice.gov.uk`.
-> [!NOTE]  
+
+> **NOTE:**
 > The environment is not explicitly stated in the production URL.
 
 ### Example URLs

--- a/source/documentation/apps/static-app.md
+++ b/source/documentation/apps/static-app.md
@@ -1,4 +1,4 @@
-# Deploying a static webapp
+# Deploying a Webapp
 
 ## GitHub Repository
 
@@ -245,18 +245,11 @@ The `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET` that have been added will be use
 [Click here for further information about deployments](https://user-guidance.analytical-platform.service.justice.gov.uk/apps/rshiny-app.html#overview).
 
 
-## Manage Existing Applications
-
-### Manage Application Users
-
-To grant access to someone, in the [Control Panel wepapps tab](https://controlpanel.services.analytical-platform.service.justice.gov.uk/webapps) find your App and click "Manage App". In the 'App customers' section you can let people view your app by putting one or more email addresses in the text box and clicking "Add customer".
-
-> **IMPORTANT:**
-> The "Manage Customers" page is only applicable to apps that use the "email" authentication process for login, which is enabled by default.
 
 ## Accessing the Application
 
 URLs for respective environments are as follows:
+
 - Development: `<repository-name>-dev.apps.live.cloud-platform.service.justice.gov.uk`.
 - Production: `<repository-name>.apps.live.cloud-platform.service.justice.gov.uk`.
 
@@ -265,10 +258,12 @@ URLs for respective environments are as follows:
 
 ### Example URLs
 
-For an example project with a repo called "static-web-deploy", the respective deployment URLs would be:
-- Development: `https://static-web-deploy-dev.apps.live.cloud-platform.service.justice.gov.uk`
-- Production: `https://static-web-deploy.apps.live.cloud-platform.service.justice.gov.uk`
+For an example project with a repo called "example-webapp", the respective deployment URLs would be:
+- Development: `https://example-webapp-dev.apps.live.cloud-platform.service.justice.gov.uk`
+- Production: `https://example-webapp.apps.live.cloud-platform.service.justice.gov.uk`
 
 Note that characters that are not compatible with website URLs are converted. Therefore repositories with underscores in their name (e.g. `repository_name.apps...`) will be converted to dashes for the URL (e.g. `repository-name.apps...`).
 
-![](images/static/static_deployed.gif)
+### Managing your Application
+
+[Further information about managing deployed apps, including managing user access, can be found in the Managing published apps section.](/apps/rshiny-app.html#managing-published-apps)


### PR DESCRIPTION
- Update the ordering of the apps section, to move the deployment section higher up
- Remove notices that say that we are not accepting new apps
- Remove references to "static webapps" - use generic "webapps" instead
- The `!IMPORTANT` and `!NOTE` blocks were not picked up correctly on the deployed user guidance, so changes these to use a bold style.