### PR TITLE
Minor updates to user guidance

### DIFF
--- a/source/documentation/apps/static-app.md
+++ b/source/documentation/apps/static-app.md
@@ -95,18 +95,8 @@ You can follow the instructions for each step individually, with a pull request 
 
 > Note: It is important you create the namespace with the correct name to begin with. Changing the namespace afterwards will likely cause breaking changes on deployment.
 
-[Follow the "Creating a Cloud Platform environment" instructions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/env-create.html#creating-a-cloud-platform-environment) to create your namespace. Please note, your namespace name **must** follow the format of:
+[Follow the "Creating a Cloud Platform environment" instructions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/env-create.html#creating-a-cloud-platform-environment) to create your namespace. Your namespace must meet the Ministry of Justice’s guidance on [naming things](https://technical-guidance.service.justice.gov.uk/documentation/standards/naming-things.html).
 
-```data-platform-app-<repo-name>-<env>```
-
-The `<repo-name>` should be the name of the repository you set up in the [previous step](#create-a-repository-from-the-template), not the full url.
-
-The `<env>` should be `dev` or `prod` based on which environment you are setting up. E.g.
-
-```
-data-platform-app-my-github-repo-dev
-data-platform-app-app-my-github-repo-prod
-```
 
 In addition, you will need to update the generated `01-rbac.yaml` file in your namespace directory to add the `analytics-hq` team. Open the file, and under the `subjects` section, add the following below the existing entry:
 
@@ -224,6 +214,7 @@ You can see a [full example of a namespace directory](https://github.com/ministr
 1. Login to the [Control Panel](https://controlpanel.services.analytical-platform.service.justice.gov.uk)
 1. Click the "Webapps" link in the main navigation, and click the "Register app" button at the bottom of the page
 1. Enter the full URL of your GitHub repository
+1. Enter your Cloud Platform namespace, without any env suffix
 1. Choose to create a new webapp data source (S3 bucket), connect an existing data source, or choose to do this later.
 > **NOTE:**
 > If you choose "Do this later" you will be able to create a Webapp data source by clicking the "Webapp data" button in the main navigation after registering your app. You will then need to come back to the "Manage app" page to link it to your Application.

--- a/source/documentation/get-started.md
+++ b/source/documentation/get-started.md
@@ -95,11 +95,9 @@ If you do not receive a response within 24 hours, request access in either the *
 
 ### Sign in to the Control Panel
 
-The main entry point to the Analytical Platform is the [Control Panel](https://controlpanel.services.analytical-platform.service.justice.gov.uk/). From there, you configure core tools such as JupyterLab, RStudio and Visual Studio Code.
+The main entry point to the Analytical Platform is the [Control Panel](https://controlpanel.services.analytical-platform.service.justice.gov.uk/). From there, you configure core tools such as JupyterLab, RStudio and Visual Studio Code. You log in to the Control Panel using your GitHub account.
 
-When you access the Control Panel first time, a prompt will appear, requiring you to configure 2FA using your mobile device. Note that while you use your GitHub account to access the Control Panel, this 2FA is separate from the one you use to log in to GitHub. You may need to disable browser extensions such as Dark Mode during the 2FA setup process.
-
-After you log in to the Control Panel for the first time, you can begin requesting access to data on the platform.
+When accessing the Control Panel for the first time you will be prompted to authenticate with your Justice account. You only need to do this once, and will not see this on subsequent logins.
 
 ## 5. Set up JupyterLab
 


### PR DESCRIPTION
- Removes guidance about setting up 2FA in the AP, as this has been removed
- Update webapp registration guidance to remove namespace requirements. Users can now choose their own namespace without restriction from us.