### PR TITLE
📖 Airflow migration guidance

### DIFF
--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -20,8 +20,13 @@ In your DAG file in the airflow repo (e.g. *r_validation.py*), make the followin
         -   **Note:** `ROLE` should contain the airflow role name used by your DAG
     -   `environment="dev"` for Development environment 
     -   `environment="prod"` for Production environment
+    -   Remove `annotations={"iam.amazonaws.com/role": ROLE}` from the arguments list. 
+        -   **Note:** If you are using other annotations than the standard role one, simply remove `"iam.amazonaws.com/role": ROLE` from the list of annotations.
 -   If your DAG uses the `KubernetesPodOperator`, add the following arguments:
     -   `service_account_name=ROLE.replace("_", "-")`
     -   update `cluster_context` argument to `"analytical-platform-compute-test"` for Development environment
     -   update `cluster_context` argument to `"analytical-platform-compute-production"` for Production environment
+    -   Remove `annotations={"iam.amazonaws.com/role": ROLE}` from the arguments list.
 -   Merge the changes in a pull request in the airflow repo as normal.
+
+An example of what an updated DAG should look like is the [examples.use_kubernetes_pod_operators](https://github.com/moj-analytical-services/airflow/blob/main/environments/dev/dags/examples/use_kubernetes_pod_operators.py) DAG.

--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -3,14 +3,14 @@
 The Analytical Platform team are making changes to how and where Airflow DAGs are run, these changes are:
 
 -   Scheduling DAGs on Analytical Platform’s new compute environment
--   Replacing Kube2IAM with IRSA (IAM Roles for Service Accounts)
+-   Migrating to an AWS-recommended approach to managing access to resources
 
 >   **Note:** Airflow DAGs identified in the migration discovery that utilise internal networking (Modernisation Platform and HMCTS SDP) are not included in this initial migration phase as the networking is not ready yet.
 
 
 ### Steps to migrate Airflow DAGs to run on the new Analytical Platform Compute EKS clusters:
 
-*   Release a new version of your DAG image (e.g. *airflow-cjs-dashboard-data*), this doesn’t need any changes, just increment the version number and generate release notes.  
+*   Release a new version of your container image (e.g. *airflow-cjs-dashboard-data*), this doesn’t need any changes, just increment the version number and generate release notes.  
     *  **Note:** You do not need to use this new version in your DAG, it is just to update the ECR repository policy.
 
 In your DAG file in the airflow repo (e.g. *r_validation.py*), make the following changes:

--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -1,0 +1,26 @@
+# Migration
+
+The Analytical Platform team are making changes to how and where Airflow DAGs are run, these changes are:
+
+-   Scheduling DAGs on Analytical Platform’s new compute environment
+-   Replacing Kube2IAM with IRSA (IAM Roles for Service Accounts)
+
+Airflow DAGs identified in the migration discovery that utilise internal networking (Modernisation Platform and HMCTS SDP) are not included in this initial migration phase as the networking is not ready yet.
+
+### Steps to migrate Airflow DAGs to run on the new Analytical Platform Compute EKS clusters:
+
+*   Release a new version of your DAG image (e.g. *airflow-cjs-dashboard-data*), this doesn’t need any changes, just increment the version number and generate release notes.  
+    *  **Note:** You do not need to use this new version in your DAG, it is just to update the ECR repository policy.
+
+In your DAG file in the Airflow repo (e.g. *r_validation.py*), make the following changes:
+
+-   If your DAG uses the `BasicKubernetesPodOperator`, add the following arguments:
+    -   `service_account_name=ROLE.replace("_", "-")` 
+        -   **Note:** `ROLE` should contain the airflow role name used by your DAG
+    -   `environment="dev"` for Development environment 
+    -   `environment="prod"` for Production environment
+-   If your DAG uses the `KubernetesPodOperator`, add the following arguments:
+    -   `service_account_name=ROLE.replace("_", "-")`
+    -   update `cluster_context` argument to `"analytical-platform-compute-test"` for Development environment
+    -   update `cluster_context` argument to `"analytical-platform-compute-production"` for Production environment
+-   Merge the changes in a pull request in the *airflow* repo as normal.

--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -13,6 +13,14 @@ The Analytical Platform team are making changes to how and where Airflow DAGs ar
 *   Release a new version of your container image (e.g. *airflow-cjs-dashboard-data*), this doesn’t need any changes, just increment the version number and generate release notes.  
     *  **Note:** You do not need to use this new version in your DAG, it is just to update the ECR repository policy.
 
+# Important Note
+
+If your R packages in renv.lock or your Python packages in requirements.txt are not locked to a version, you will potentially encounter issues if newer versions of those packages are downloaded and installed. This can also occur even if all your packages are at pinned versions, as those packages themselves may have partially unpinned requirements.
+
+While we are unable to assist in resolving dependency issues, our other users have gotten great assistance in our slack [#R](https://moj.enterprise.slack.com/archives/C1PUCG719) and [#python](https://moj.enterprise.slack.com/archives/C1Q09V86S) channels.
+
+ 
+
 In your DAG file in the airflow repo (e.g. *r_validation.py*), make the following changes:
 
 -   If your DAG uses the `BasicKubernetesPodOperator`, add the following arguments:

--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -5,14 +5,15 @@ The Analytical Platform team are making changes to how and where Airflow DAGs ar
 -   Scheduling DAGs on Analytical Platform’s new compute environment
 -   Replacing Kube2IAM with IRSA (IAM Roles for Service Accounts)
 
-Airflow DAGs identified in the migration discovery that utilise internal networking (Modernisation Platform and HMCTS SDP) are not included in this initial migration phase as the networking is not ready yet.
+>   **Note:** Airflow DAGs identified in the migration discovery that utilise internal networking (Modernisation Platform and HMCTS SDP) are not included in this initial migration phase as the networking is not ready yet.
+
 
 ### Steps to migrate Airflow DAGs to run on the new Analytical Platform Compute EKS clusters:
 
 *   Release a new version of your DAG image (e.g. *airflow-cjs-dashboard-data*), this doesn’t need any changes, just increment the version number and generate release notes.  
     *  **Note:** You do not need to use this new version in your DAG, it is just to update the ECR repository policy.
 
-In your DAG file in the Airflow repo (e.g. *r_validation.py*), make the following changes:
+In your DAG file in the airflow repo (e.g. *r_validation.py*), make the following changes:
 
 -   If your DAG uses the `BasicKubernetesPodOperator`, add the following arguments:
     -   `service_account_name=ROLE.replace("_", "-")` 
@@ -23,4 +24,4 @@ In your DAG file in the Airflow repo (e.g. *r_validation.py*), make the followin
     -   `service_account_name=ROLE.replace("_", "-")`
     -   update `cluster_context` argument to `"analytical-platform-compute-test"` for Development environment
     -   update `cluster_context` argument to `"analytical-platform-compute-production"` for Production environment
--   Merge the changes in a pull request in the *airflow* repo as normal.
+-   Merge the changes in a pull request in the airflow repo as normal.

--- a/source/documentation/tools/airflow/migration.md
+++ b/source/documentation/tools/airflow/migration.md
@@ -29,4 +29,4 @@ In your DAG file in the airflow repo (e.g. *r_validation.py*), make the followin
     -   Remove `annotations={"iam.amazonaws.com/role": ROLE}` from the arguments list.
 -   Merge the changes in a pull request in the airflow repo as normal.
 
-An example of what an updated DAG should look like is the [examples.use_kubernetes_pod_operators](https://github.com/moj-analytical-services/airflow/blob/main/environments/dev/dags/examples/use_kubernetes_pod_operators.py) DAG.
+An example of what an updated DAG should look like is the [examples.use_kubernetes_pod_operators](https://github.com/moj-analytical-services/airflow/blob/main/environments/dev/dags/examples/use_kubernetes_pod_operators.py) DAG. This DAG demonstrates for the `dev` environment both an updated `BasicKubernetesPodOperator` and `KubernetesPodOperator`.

--- a/source/tools/airflow/migration.html.md.erb
+++ b/source/tools/airflow/migration.html.md.erb
@@ -1,0 +1,11 @@
+---
+title: Migration
+weight: 40
+last_reviewed_on: 2024-07-03
+review_in: 1 year
+show_expiry: true
+owner_slack: "#analytical-platform"
+owner_slack_workspace: "mojdt"
+---
+
+<%= partial 'documentation/tools/airflow/migration' %>


### PR DESCRIPTION
This pull request:

- contributes to this [ticket](https://github.com/ministryofjustice/analytical-platform/issues/4319)
- adds user guidance for migrating DAGs to use IRSA and run on the new AC Compute EKS clusters

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>