### PR TITLE
Config Block Update

### DIFF
--- a/source/documentation/tools/create-a-derived-table/deploying-to-dev.md
+++ b/source/documentation/tools/create-a-derived-table/deploying-to-dev.md
@@ -1,5 +1,17 @@
 # Deploying to Dev
 
+## Important Note - Before you deploy
+
+As detailed in the section on [models](/tools/create-a-derived-table/models), you will need to add the standardised **config block** to your model before attempting to deploy. The block is as follows:
+
+```
+{{ config(
+    external_location=generate_s3_location()
+) }}
+```
+
+If you do not include this block, your models will attempt to write to an invalid path in S3, and thusly will fail to deploy. You can include other config values in the block if doing so is useful for your model, but all models **must** include the `external_location=generate_s3_location()` statement to deploy succesfully.
+
 You can run any dbt command in the terminal in RStudio (JupyterLab coming soon) to deploy models and seeds, or to run tests. When you deploy models and seeds from RStudio the database they are built in to will be suffixed with `_dev_dbt` and the underlying data that gets generated will be written to the following S3 path:
 
 ```
@@ -68,8 +80,7 @@ To run tests on models with tests defined, run:
 dbt test --select models/.../path/to/my/models/
 ```
 
-
-## <a id="using-the-plus-prefix"></a>Using the + prefix 
+## <a id="using-the-plus-prefix"></a>Using the + prefix
 
 The `+` prefix is a `dbt` syntax feature which helps disambiguate between resource paths and configurations in the `dbt_project.yml` file. If you see it used in the `dbt_project.yml` file and wonder what it is, read [dbt's guidance on using the `+` prefix](https://docs.getdbt.com/reference/resource-configs/plus-prefix). It is also used to configure properties in a nested dictionary which take a dictionary of values in a model, seed or test config `.yaml`. For example, use `+column_types` rather than `column_types` since what follows are further key and value pairs defining the column names and the required data type. It doesn't hurt to use `+` prefix so it is recommended to always do so.
 
@@ -88,7 +99,6 @@ models:
         column_2: int
         column_3: string
 ```
-
 
 ## How to use the incremental materialisation with the append strategy
 

--- a/source/documentation/tools/create-a-derived-table/models.md
+++ b/source/documentation/tools/create-a-derived-table/models.md
@@ -59,7 +59,7 @@ models:
       partitioned_by: ['snapshot_date']
       +column_types:
         column_1: varchar(5)
-        column_2: int    
+        column_2: int
 ```
 
 If for some reason it is not possible or reasonable to apply a configuration in a property file, you can use a `config()` Jinja macro within a model or test SQL file. The following example shows how the same configuration above can be applied in a model or test file.
@@ -70,14 +70,26 @@ If for some reason it is not possible or reasonable to apply a configuration in 
       materialized='incremental'
       incremental_strategy='append'
       partitioned_by=['snapshot_date']
+      external_location=generate_s3_location()
   )
 }}
 ```
 
+## Important - Required Config
+
+In order to ensure that data is stored in an orderly manner within the bucket, we enforce a specific naming convention through use of a build in macro to generate the file path your data will be saved in S3 with. This is done through the config block within the SQL definition of the model, and is usually seen as starting the file with the following:
+
+```
+{{ config(
+    external_location=generate_s3_location()
+) }}
+```
+
+Although it is possible to apply further config values by the methods detailed before as an optional feature, the config block itself **must** feature the `external_location=generate_s3_location()` statement at a minimum. Failing to supply this config value will cause the table to attempt to deploy to an incorrect location and then fail with a generic `access denied` error.
+
 ## Config inheritance
 
 Configurations are prioritised in order of specificity, which is generally the inverse of the order above: an in-file `config()` block takes precedence over properties defied in a `.yaml` property file, which takes precedence over a configuration defined in the `dbt_project.yml` file. (Note that generic tests work a little differently when it comes to specificity. See dbt's documentation on [test configs](https://docs.getdbt.com/reference/test-configs).)
-
 
 ## Materialisations
 


### PR DESCRIPTION
Adding some guidance on a required config element of CaDeT that used to be included as part of our 'migration guidance'. Now that said migration is long over, this required info should be integrated into our regular docs.