### PR TITLE
:octocat: Add Octo STS documentation

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.11.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099",
+      "integrity": "sha256:503f23cd692325b3cbb8c20a0ecfabb3444b0c786b363e0c82572bd7d71dc099"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "analytical-platform-user-guidance",
+  "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "GitHub.vscode-github-actions",
+        "GitHub.vscode-pull-request-github"
+      ],
+      "settings": {
+        "files.associations": {
+          "*.html.md.erb": "markdown"
+        }
+      }
+    }
+  }
+}

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -39,5 +39,5 @@ owner_slack_workspace: asdslack
 default_owner_slack: '#analytical-platform-support'
 
 footer_links:
-  Get in touch by email: mailto:analytical_platform@digital.justice.gov.uk
+  Get in touch by email: mailto:analytical-platform@digital.justice.gov.uk
   Get in touch by Slack: https://app.slack.com/client/T02DYEB3A/C4PF7QAJZ

--- a/source/documentation/github/accessing-private-repositories-from-github-actions.md
+++ b/source/documentation/github/accessing-private-repositories-from-github-actions.md
@@ -1,0 +1,48 @@
+# Accessing private repositories from GitHub Actions
+
+> This feature is currently experimental and only applies to `moj-analytical-services`
+
+There are use cases where projects need to consume other private projects in GitHub Actions. Traditionally, this has meant project teams must generate deploy keys or personal access tokens (PAT). However, this adds the overhead of managing these secrets.
+
+The Analytical Platform team has installed [Octo STS](https://github.com/apps/octo-sts) to alleviate the requirement for deploy keys or personal access tokens.
+
+To make use of this, you will need to do the following:
+
+1. Create an Octo STS definition in the repository you want to consume
+   
+    `.github/chainguard/${IDENTITY}.sts.yaml` where `${IDENTITY}` is a reference to your repository, e.g. `.github/chainguard/airflow-create-a-pipeline.sts.yaml`
+
+    This example gives all workflow on all branches access to read contents.
+
+    ```yaml
+    ---
+    issuer: https://token.actions.githubusercontent.com
+    subject: repo:moj-analytical-services/airflow-create-a-pipeline:.*
+
+    permissions:
+      contents: read
+    ```
+
+
+1. Retrieve the token in repository you consuming the private repository from
+
+    ```yaml
+    - name: Obtain Octo STS Token
+      uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo_sts
+      with:
+        scope: moj-analytical-services/private-repository # Reference to repository you you want to consume
+        identity: airflow-create-a-pipeline               # Reference to ${IDENTITY}
+    ```
+
+1. You can then use the output token to clone the repository
+
+    ```yaml
+    - name: Checkout moj-analytical-services/private-repository
+      id: checkout_private_repo
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        token: ${{ steps.octo_sts.outputs.token }}
+        repository: moj-analytical-services/private-repository
+        path: private-repository
+    ```

--- a/source/github/accessing-private-repositories-from-github-actions.html.md.erb
+++ b/source/github/accessing-private-repositories-from-github-actions.html.md.erb
@@ -1,0 +1,10 @@
+---
+title: Accessing private repositories from GitHub Actions
+weight: 100
+last_reviewed_on: 2024-08-27
+review_in: 12 months
+owner_slack: "#analytical-platform-support"
+owner_slack_workspace: "mojdt"
+---
+
+<%= partial 'documentation/github/accessing-private-repositories-from-github-actions' %>


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/analytical-platform/issues/5134
- Adds documentation for using Octo STS
- Adds a dev container
- Fixes email address in the config

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 