### PR TITLE
:memo: Explicitly declare email, fox broken link

### DIFF
--- a/source/documentation/get-started.md
+++ b/source/documentation/get-started.md
@@ -91,7 +91,7 @@ To request an invitation Analytical Platform GitHub Organisation, please head ov
 > **Example**
 > 👋 Could I please be added to the Analytical Services GitHub Org, my github name is `github user name` thank you.
 
-If you do not receive a response within 24 hours, request access in either the **#ask-operations-engineering** Slack channel or email [here](operations-engineering@digital.justice.gov.uk), providing your GitHub username in your message.
+If you do not receive a response within 24 hours, request access in either the **#ask-operations-engineering** Slack channel or email `operations-engineering@digital.justice.gov.uk`, providing your GitHub username in your message.
 
 ### Sign in to the Control Panel
 


### PR DESCRIPTION
This PR declares the email explicitly, the previous link redirects to a webpage which 404's. 