### PR TITLE
Add join github link

### DIFF
--- a/source/documentation/github/index.md
+++ b/source/documentation/github/index.md
@@ -17,6 +17,10 @@ You can read more about the [benefits of GitHub](../annexes.html#benefits-of-usi
 
 All code written on the Analytical Platform should be stored in a [git repository](create-project.html) on GitHub in the [MoJ Analytical Services](organisation-management.html) organisation. This includes R scripts, Python scripts and Jupyter notebooks.
 
+### Join GitHub
+
+To create a GitHub account, please use the [Join Github](https://join-github.service.justice.gov.uk/) service.  If you experience any issues using this service please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
+
 ### Get started
 
 If you're new to git or GitHub, you may find it useful to take a look at the [learning resources](learning-resources.html) before getting started.


### PR DESCRIPTION
This PR adds a link for the Join GitHub service to the AP user guidance docs

user-guidance/main/source/documentation/github/index.md has been updated with a Join GitHub section, a link to the service and a link to the 'ask-operations-engineering' Slack channel for support