### PR TITLE
Update get-started.md with SSO auth for SSH keys

### DIFF
--- a/source/documentation/get-started.md
+++ b/source/documentation/get-started.md
@@ -134,6 +134,8 @@ $ cat /home/jovyan/.ssh/id_rsa.pub
 
 You then need to add the SSH key to GitHub; see the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for instructions.
 
+You also need to authorise your SSH key for use with the MoJ-Analytical-Services organisation before you can use it; see [GitHub: Authorizing an SSH key](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on#authorizing-an-ssh-key) for instructions.
+
 ## 6. Set up RStudio
 
 >**Note**: Only follow this step if you want to use the Analytical Platform as an R-based user. RStudio supports Python, but we recommend using JupyterLab for Python instead. If you configured JupyterLab in the previous step, proceed to step 7.
@@ -156,6 +158,8 @@ To create an SSH key in RStudio:
 6. Select **View public key** and copy the SSH key to your clipboard
 
 You then need to add the SSH key to GitHub; see the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for instructions.
+
+You also need to authorise your SSH key for use with the MoJ-Analytical-Services organisation before you can use it; see [GitHub: Authorizing an SSH key](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on#authorizing-an-ssh-key) for instructions.
 
 Now that you have completed this guide you are ready to begin using the Analytical Platform. See [training](training.md) for a list of different resources to help you begin using the platform.
 
@@ -190,3 +194,5 @@ $ cat ~/.ssh/id_ed25519.pub
 8. Copy the SSH key to your clipboard
 
 You then need to add the SSH key to GitHub; see the [GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) for instructions.
+
+You also need to authorise your SSH key for use with the MoJ-Analytical-Services organisation before you can use it; see [GitHub: Authorizing an SSH key](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on#authorizing-an-ssh-key) for instructions.


### PR DESCRIPTION
We just had a new starter who followed this guidance but couldn't clone any repos.  It turned out his SSH key wasn't authorised for use with the moj-analytical-services org, so I assume this is a new step everyone now needs given the recent changes to sign-on?

This adds the new step to the quickstart (for each tool) to stop anyone else tripping up on this.  Does this work?  I am not an expert in the new auth process!