### PR TITLE
Use new Google Analytics tag

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,7 +16,7 @@ header_links:
 enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
-ga_tracking_id: G-R6XQGCZFY1
+# ga_tracking_id: G-R6XQGCZFY1
 
 # Enable multipage navigation in the sidebar
 multipage_nav: true

--- a/source/annexes.html.md.erb
+++ b/source/annexes.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/annexes' %>

--- a/source/appendix/athena.html.md.erb
+++ b/source/appendix/athena.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/appendix-docs/athena' %>

--- a/source/appendix/botor.html.md.erb
+++ b/source/appendix/botor.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/appendix-docs/botor' %>

--- a/source/appendix/dash.html.md.erb
+++ b/source/appendix/dash.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/appendix-docs/app_development' %>

--- a/source/appendix/index.html.md.erb
+++ b/source/appendix/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/appendix-docs/index' %>

--- a/source/apps/alerting.html.md.erb
+++ b/source/apps/alerting.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/apps/alerting' %>

--- a/source/apps/index.html.md.erb
+++ b/source/apps/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/apps/index' %>

--- a/source/apps/manage-app-settings-from-cpanel.html.md.erb
+++ b/source/apps/manage-app-settings-from-cpanel.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/apps/manage-app-settings-from-cpanel' %>

--- a/source/apps/rshiny-app.html.md.erb
+++ b/source/apps/rshiny-app.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/apps/rshiny-app' %>

--- a/source/apps/static-app.html.md.erb
+++ b/source/apps/static-app.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/apps/static-app' %>

--- a/source/aup.html.md.erb
+++ b/source/aup.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/aup' %>

--- a/source/data/amazon-s3/index.html.md.erb
+++ b/source/data/amazon-s3/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/amazon-s3' %>

--- a/source/data/curated-databases/amazon-athena/index.html.md.erb
+++ b/source/data/curated-databases/amazon-athena/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/amazon-athena' %>

--- a/source/data/curated-databases/data-documentation/index.html.md.erb
+++ b/source/data/curated-databases/data-documentation/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/data-documentation' %>

--- a/source/data/curated-databases/data-linking/index.html.md.erb
+++ b/source/data/curated-databases/data-linking/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-linking'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/data-linking' %>

--- a/source/data/curated-databases/databases-for-analysis-and-apps/index.html.md.erb
+++ b/source/data/curated-databases/databases-for-analysis-and-apps/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/databases-for-analysis-and-apps' %>

--- a/source/data/curated-databases/databases/index.html.md.erb
+++ b/source/data/curated-databases/databases/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/databases' %>

--- a/source/data/curated-databases/dbtools/index.html.md.erb
+++ b/source/data/curated-databases/dbtools/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/dbtools' %>

--- a/source/data/curated-databases/index.html.md.erb
+++ b/source/data/curated-databases/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/index' %>

--- a/source/data/curated-databases/sql/index.html.md.erb
+++ b/source/data/curated-databases/sql/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/curated-databases-docs/sql' %>

--- a/source/data/data-faqs/index.html.md.erb
+++ b/source/data/data-faqs/index.html.md.erb
@@ -7,4 +7,14 @@ show_expiry: true
 owner_slack: '#ask-data-engineering'
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/data-faqs/index' %>

--- a/source/data/exporting-data.html.md.erb
+++ b/source/data/exporting-data.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#data_engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/exporting-data' %>

--- a/source/data/home-directories/index.html.md.erb
+++ b/source/data/home-directories/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/home-directories' %>

--- a/source/data/index.html.md.erb
+++ b/source/data/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/data-docs/index' %>

--- a/source/errors.html.md.erb
+++ b/source/errors.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/errors' %>

--- a/source/faq.html.md.erb
+++ b/source/faq.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/faq' %>

--- a/source/get-started.html.md.erb
+++ b/source/get-started.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/get-started' %>

--- a/source/github/accessing-private-repositories-from-github-actions.html.md.erb
+++ b/source/github/accessing-private-repositories-from-github-actions.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/accessing-private-repositories-from-github-actions' %>

--- a/source/github/collaborate-on-project.html.md.erb
+++ b/source/github/collaborate-on-project.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/collaborate-on-project' %>

--- a/source/github/command-line-git.html.md.erb
+++ b/source/github/command-line-git.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/command-line-git' %>

--- a/source/github/create-project.html.md.erb
+++ b/source/github/create-project.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/create-project' %>

--- a/source/github/index.html.md.erb
+++ b/source/github/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/index' %>

--- a/source/github/install-packages.html.md.erb
+++ b/source/github/install-packages.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/install-packages' %>

--- a/source/github/jupyterlab-git.html.md.erb
+++ b/source/github/jupyterlab-git.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/jupyterlab-git' %>

--- a/source/github/learning-resources.html.md.erb
+++ b/source/github/learning-resources.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/learning-resources' %>

--- a/source/github/manage-access.html.md.erb
+++ b/source/github/manage-access.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/manage-access' %>

--- a/source/github/organisation-management.html.md.erb
+++ b/source/github/organisation-management.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/organisation-management' %>

--- a/source/github/rstudio-git.html.md.erb
+++ b/source/github/rstudio-git.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/rstudio-git' %>

--- a/source/github/security-in-github.html.md.erb
+++ b/source/github/security-in-github.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/security-in-github' %>

--- a/source/github/set-up-github.html.md.erb
+++ b/source/github/set-up-github.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/github/set-up-github' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/index' %>

--- a/source/information-governance.html.md.erb
+++ b/source/information-governance.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/information-governance' %>

--- a/source/parameters.html.md.erb
+++ b/source/parameters.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/parameters' %>

--- a/source/shared-responsibility-model.html.md.erb
+++ b/source/shared-responsibility-model.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/shared-responsibility-model' %>

--- a/source/support.html.md.erb
+++ b/source/support.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/support' %>

--- a/source/tools/airflow/concepts/index.html.md.erb
+++ b/source/tools/airflow/concepts/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/concepts' %>

--- a/source/tools/airflow/gpu-workloads.html.md.erb
+++ b/source/tools/airflow/gpu-workloads.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/gpu-workloads' %>

--- a/source/tools/airflow/index.html.md.erb
+++ b/source/tools/airflow/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/index' %>

--- a/source/tools/airflow/instructions/dag-pipeline/index.html.md.erb
+++ b/source/tools/airflow/instructions/dag-pipeline/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/instructions/dag-pipeline' %>

--- a/source/tools/airflow/instructions/image-pipeline/index.html.md.erb
+++ b/source/tools/airflow/instructions/image-pipeline/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/instructions/image-pipeline' %>

--- a/source/tools/airflow/instructions/index.html.md.erb
+++ b/source/tools/airflow/instructions/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/instructions/index' %>

--- a/source/tools/airflow/migration.html.md.erb
+++ b/source/tools/airflow/migration.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/migration' %>

--- a/source/tools/airflow/troubleshooting/index.html.md.erb
+++ b/source/tools/airflow/troubleshooting/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/airflow/troubleshooting' %>

--- a/source/tools/bedrock/index.html.md.erb
+++ b/source/tools/bedrock/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/bedrock/index' %>

--- a/source/tools/control-panel.html.md.erb
+++ b/source/tools/control-panel.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/control-panel' %>

--- a/source/tools/create-a-derived-table/collaborating-with-git/index.html.md.erb
+++ b/source/tools/create-a-derived-table/collaborating-with-git/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/collaborating-with-git' %>

--- a/source/tools/create-a-derived-table/database-access/index.html.md.erb
+++ b/source/tools/create-a-derived-table/database-access/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/database-access' %>

--- a/source/tools/create-a-derived-table/dbt-athena-upgrade-guidance/index.html.md.erb
+++ b/source/tools/create-a-derived-table/dbt-athena-upgrade-guidance/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/dbt-athena-upgrade-guidance' %>

--- a/source/tools/create-a-derived-table/deploying-to-dev/index.html.md.erb
+++ b/source/tools/create-a-derived-table/deploying-to-dev/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/deploying-to-dev' %>

--- a/source/tools/create-a-derived-table/ide-set-up/index.html.md.erb
+++ b/source/tools/create-a-derived-table/ide-set-up/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/ide-set-up' %>

--- a/source/tools/create-a-derived-table/index.html.md.erb
+++ b/source/tools/create-a-derived-table/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/index' %>

--- a/source/tools/create-a-derived-table/linting-sql-files/index.html.md.erb
+++ b/source/tools/create-a-derived-table/linting-sql-files/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/linting-sql-files' %>

--- a/source/tools/create-a-derived-table/linting-yaml-files/index.html.md.erb
+++ b/source/tools/create-a-derived-table/linting-yaml-files/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/linting-yaml-files' %>

--- a/source/tools/create-a-derived-table/macros/index.html.md.erb
+++ b/source/tools/create-a-derived-table/macros/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/macros' %>

--- a/source/tools/create-a-derived-table/models/index.html.md.erb
+++ b/source/tools/create-a-derived-table/models/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/models' %>

--- a/source/tools/create-a-derived-table/project-structure/index.html.md.erb
+++ b/source/tools/create-a-derived-table/project-structure/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/project-structure' %>

--- a/source/tools/create-a-derived-table/quick-reference/index.html.md.erb
+++ b/source/tools/create-a-derived-table/quick-reference/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/quick-reference' %>

--- a/source/tools/create-a-derived-table/scheduling-to-prod/index.html.md.erb
+++ b/source/tools/create-a-derived-table/scheduling-to-prod/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/scheduling-to-prod' %>

--- a/source/tools/create-a-derived-table/seeds/index.html.md.erb
+++ b/source/tools/create-a-derived-table/seeds/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/seeds' %>

--- a/source/tools/create-a-derived-table/source-and-ref-functions/index.html.md.erb
+++ b/source/tools/create-a-derived-table/source-and-ref-functions/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/source-and-ref-functions' %>

--- a/source/tools/create-a-derived-table/style-guide/index.html.md.erb
+++ b/source/tools/create-a-derived-table/style-guide/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/style-guide' %>

--- a/source/tools/create-a-derived-table/tests/index.html.md.erb
+++ b/source/tools/create-a-derived-table/tests/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/tests' %>

--- a/source/tools/create-a-derived-table/troubleshooting/index.html.md.erb
+++ b/source/tools/create-a-derived-table/troubleshooting/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/troubleshooting' %>

--- a/source/tools/create-a-derived-table/what-data-is-on-create-a-derived-table/index.html.md.erb
+++ b/source/tools/create-a-derived-table/what-data-is-on-create-a-derived-table/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/what-data-is-on-create-a-derived-table' %>

--- a/source/tools/create-a-derived-table/what-is-create-a-derived-table/index.html.md.erb
+++ b/source/tools/create-a-derived-table/what-is-create-a-derived-table/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-modelling"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/create-a-derived-table/what-is-create-a-derived-table' %>

--- a/source/tools/data-processing/index.html.md.erb
+++ b/source/tools/data-processing/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/data-processing/tools-for-data-processing' %>

--- a/source/tools/data-uploader/index.html.md.erb
+++ b/source/tools/data-uploader/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#ask-data-engineering"
 owner_slack_workspace: "asdslack"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/data-uploader/index' %>

--- a/source/tools/index.html.md.erb
+++ b/source/tools/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/index' %>

--- a/source/tools/ingestion/index.html.md.erb
+++ b/source/tools/ingestion/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/ingestion/index' %>

--- a/source/tools/jupyterlab/index.html.md.erb
+++ b/source/tools/jupyterlab/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/jupyterlab/index' %>

--- a/source/tools/jupyterlab/package-management.html.md.erb
+++ b/source/tools/jupyterlab/package-management.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/jupyterlab/package-management' %>

--- a/source/tools/mlflow-tracking-server/index.html.md.erb
+++ b/source/tools/mlflow-tracking-server/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/mlflow-tracking-server/index' %>

--- a/source/tools/quicksight/best-practices.html.md.erb
+++ b/source/tools/quicksight/best-practices.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/best-practices' %>

--- a/source/tools/quicksight/faqs.html.md.erb
+++ b/source/tools/quicksight/faqs.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/faqs' %>

--- a/source/tools/quicksight/getting-started.html.md.erb
+++ b/source/tools/quicksight/getting-started.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/02-getting-started' %>

--- a/source/tools/quicksight/index.html.md.erb
+++ b/source/tools/quicksight/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/01-index' %>

--- a/source/tools/quicksight/troubleshooting.html.md.erb
+++ b/source/tools/quicksight/troubleshooting.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/troubleshooting' %>

--- a/source/tools/quicksight/working-with-quicksight.html.md.erb
+++ b/source/tools/quicksight/working-with-quicksight.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/quicksight/03-working-with-quicksight' %>

--- a/source/tools/rstudio/index.html.md.erb
+++ b/source/tools/rstudio/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/rstudio/index' %>

--- a/source/tools/rstudio/package-management.html.md.erb
+++ b/source/tools/rstudio/package-management.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/rstudio/package-management' %>

--- a/source/tools/rstudio/upgrading.html.md.erb
+++ b/source/tools/rstudio/upgrading.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/rstudio/upgrading' %>

--- a/source/tools/visual-studio-code/index.html.md.erb
+++ b/source/tools/visual-studio-code/index.html.md.erb
@@ -7,4 +7,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/visual-studio-code/index' %>

--- a/source/tools/visual-studio-code/ollama/index.html.md.erb
+++ b/source/tools/visual-studio-code/ollama/index.html.md.erb
@@ -8,4 +8,14 @@ owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"
 ---
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R6XQGCZFY1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-R6XQGCZFY1');
+</script>
+
 <%= partial 'documentation/tools/visual-studio-code/ollama' %>


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/analytical-platform/issues/6255

## Proposed Changes

- Comments out `ga_tracking_id` because it invokes old Google Analytics script
- Manually enable new script for all pages

## Notes

- This should be coming soon in an update to tech docs gem https://github.com/alphagov/tech-docs-gem/pull/350

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>