### PR TITLE
Changing references to #ask-data-engineering in Airflow docs

### DIFF
--- a/source/documentation/tools/airflow/index.md
+++ b/source/documentation/tools/airflow/index.md
@@ -15,7 +15,7 @@
 - [Airflow repo](https://github.com/moj-analytical-services/airflow): Github repo to store Airflow DAGs and roles
 - [Airflow template for Python](https://github.com/moj-analytical-services/template-airflow-python): Github template repository for creating a Python image to run an Airflow pipeline
 - [Airflow template for R](https://github.com/moj-analytical-services/template-airflow-r): Github template repository for creating an R image to run an Airflow pipeline
-- Support: contact the Data Engineering team on [#ask-data-engineering](https://asdslack.slack.com/archives/C8X3PP1TN)
+- Support: contact the Analytical Platform team on [#ask-analytical-platform](https://moj.enterprise.slack.com/archives/C06TFT94JTC)
 
 ## To find out more
 

--- a/source/documentation/tools/airflow/index.md
+++ b/source/documentation/tools/airflow/index.md
@@ -1,8 +1,11 @@
 # Airflow
 
-> This documentation is for the Data Engineering Airflow service.
+> **Important**
 >
-> For Analytical Platform Airflow, please refer to [Analytical Platform Airflow](/services/airflow)
+> This documentation is for the now deprecated Data Engineering Airflow service.
+> This service is now in updates only mode, and will be shuttered on July 8th 2025.
+>
+> Please refer to [Analytical Platform Airflow](/services/airflow) for more information on our new Airflow service.
 
 
 [Airflow](https://airflow.apache.org) is a platform to programmatically author, schedule and monitor workflows

--- a/source/documentation/tools/airflow/instructions/dag-pipeline.md
+++ b/source/documentation/tools/airflow/instructions/dag-pipeline.md
@@ -252,6 +252,6 @@ airflow
 │   │   └── APPROVAL REQUIRED
 ```
     
-4.  Once checks pass and PR approved by DE, please merge the PR into main
+4.  Once checks pass and PR is approved in #ask-analytical-platform by the Analytical Platform Team, please merge the PR into main
     
 5.  The code in main is then automatically deployed to the Airflow prod and dev instances

--- a/source/documentation/tools/airflow/instructions/index.md
+++ b/source/documentation/tools/airflow/instructions/index.md
@@ -8,7 +8,7 @@ These instructions will show you how to build and run a standard Airflow pipelin
 
 - [Analytical Platform Account](get-started)
 
-- [Slack Account](get-started) Channel: #ask-data-engineering
+- [Slack Account](get-started) Channel: #ask-analytical-platform
 
 ## Create image and save to ECR
 

--- a/source/tools/airflow/concepts/index.html.md.erb
+++ b/source/tools/airflow/concepts/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Airflow Concepts
 weight: 20
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 2 months
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/tools/airflow/index.html.md.erb
+++ b/source/tools/airflow/index.html.md.erb
@@ -1,10 +1,10 @@
 ---
 title: Airflow
 weight: 40
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 1 year
 show_expiry: true
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/tools/airflow/instructions/dag-pipeline/index.html.md.erb
+++ b/source/tools/airflow/instructions/dag-pipeline/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: DAG Pipeline
 weight: 30
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 2 months
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/tools/airflow/instructions/image-pipeline/index.html.md.erb
+++ b/source/tools/airflow/instructions/image-pipeline/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Image Pipeline
 weight: 30
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 2 months
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/tools/airflow/instructions/index.html.md.erb
+++ b/source/tools/airflow/instructions/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Airflow Instructions
 weight: 30
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 2 months
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/tools/airflow/troubleshooting/index.html.md.erb
+++ b/source/tools/airflow/troubleshooting/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Troubleshooting Airflow Pipelines
 weight: 40
-last_reviewed_on: 2022-05-07
+last_reviewed_on: 2025-04-07
 review_in: 2 months
-owner_slack: "#ask-data-engineering"
+owner_slack: "#ask-analytical-platform"
 owner_slack_workspace: "mojdt"
 ---
 


### PR DESCRIPTION
This updates the ownership of Airflow related pages/links to point to the Analytical Platform Team