### PR TITLE
Add textract and comprehend docs

### DIFF
--- a/source/documentation/tools/index.md
+++ b/source/documentation/tools/index.md
@@ -19,6 +19,9 @@ Online hosting platform for git. Git is a distributed version control system tha
 ### [QuickSight](quicksight)
 Business Intelligence (BI/MI) tool for visualising / dashboarding data.
 
+### [Dashboard Service](dashboard-service)
+Securely share dashboards created in QuickSight with other users.
+
 ## Data Ingest
 
 ### [Data Extractor](https://github.com/ministryofjustice/data-engineering-data-extractor)
@@ -35,7 +38,7 @@ Moves data from microservices into the Analytical Platform's [curated databases]
 
 ## Integrated Development Environments (IDE)
 
-### [Amazon Athena Console](https://user-guidance.analytical-platform.service.justice.gov.uk/data/curated-databases/amazon-athena/#amazon-athena)
+### [Amazon Athena Console](/data/curated-databases/amazon-athena/#amazon-athena)
 Amazon Athena is an interactive query service that makes it easy to analyze data directly in Amazon Simple Storage Service (Amazon S3) using standard SQL. See  [Athena documentation](https://user-guidance.analytical-platform.service.justice.gov.uk/data/curated-databases/amazon-athena/#amazon-athena) for more information.
 
 ### [JupyterLab](jupyterlab)
@@ -49,7 +52,7 @@ General purpose code editor. For more information, see the [Visual Studio Code d
 
 ## Orchestration
 
-### [Airflow](airflow)
+### [Airflow](/services/airflow/)
 A tool for scheduling and monitoring workflows.
 
 ### [Create a Derived Table](create-a-derived-table)

--- a/source/tools/index.html.md.erb
+++ b/source/tools/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Tools
 weight: 50
-last_reviewed_on: 2022-12-08
+last_reviewed_on: 2025-07-07
 review_in: 1 year
 show_expiry: true
 owner_slack: "#analytical-platform-support"


### PR DESCRIPTION
Update the [tools and services page](https://user-guidance.analytical-platform.service.justice.gov.uk/tools/) to add Textract and Comprehend.

Link to the AWS docs for both, as the AP team will not provide usage instructions.

![image](https://github.com/user-attachments/assets/743ed48f-2c56-46f1-b7e4-a24707c5706b)
