### PR TITLE
Update Airflow workflow scheduling docs

### DIFF
--- a/source/documentation/services/airflow/index.md
+++ b/source/documentation/services/airflow/index.md
@@ -164,7 +164,7 @@ The following options are available under `dag`:
 - `schedule`: [cron expression](https://crontab.guru/) that defines how often the workflow runs (defaults to `null`), can also use dataset scheduling as shown in the [example-dataset-schedule workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-dataset-schedule/workflow.yml)
 - `start_date`: the timestamp (`YYYY-MM-DD`) from which the scheduler will attempt to backfill (defaults to `2025-01-01`)
 - `inlets`: used to provide lineage when using dataset scheduling. An example is shown in the [example-dataset-schedule workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-dataset-schedule/workflow.yml)
-- `outlets`: used in conjunction with downstram dataset scheduling. An example is shown in the [example-outlet workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-outlet/workflow.yml)
+- `outlets`: used in conjunction with downstream dataset scheduling. An example is shown in the [example-outlet workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-outlet/workflow.yml)
 
 
 The [`example-schedule` workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-schedule/workflow.yml) shows an example of a workflow that runs at 08:00 every day and retries 3 times, with a 150 second delay between each retry:

--- a/source/documentation/services/airflow/index.md
+++ b/source/documentation/services/airflow/index.md
@@ -161,8 +161,11 @@ The following options are available under `dag`:
 - `max_active_runs`: maximum number of active workflow runs (defaults to `1`)
 - `retries`: the number of retries that should be performed before failing the task (defaults to `0`)
 - `retry_delay`: delay in seconds between retries (defaults to `300`)
-- `schedule`: [cron expression](https://crontab.guru/) that defines how often the workflow runs (defaults to `null`)
+- `schedule`: [cron expression](https://crontab.guru/) that defines how often the workflow runs (defaults to `null`), can also use dataset scheduling as shown in the example-dataset-schedule workflow in development
 - `start_date`: the timestamp (`YYYY-MM-DD`) from which the scheduler will attempt to backfill (defaults to `2025-01-01`)
+- `inlets`: used to provide lineage when using dataset scheduling. An example is shown in the example-dataset-schedule worflow in development
+- `outlets`: used in conjunction with downstram dataset scheduling. An example is shown in the example-outlet worflow in development
+
 
 The [`example-schedule` workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-schedule/workflow.yml) shows an example of a workflow that runs at 08:00 every day and retries 3 times, with a 150 second delay between each retry:
 

--- a/source/documentation/services/airflow/index.md
+++ b/source/documentation/services/airflow/index.md
@@ -161,10 +161,10 @@ The following options are available under `dag`:
 - `max_active_runs`: maximum number of active workflow runs (defaults to `1`)
 - `retries`: the number of retries that should be performed before failing the task (defaults to `0`)
 - `retry_delay`: delay in seconds between retries (defaults to `300`)
-- `schedule`: [cron expression](https://crontab.guru/) that defines how often the workflow runs (defaults to `null`), can also use dataset scheduling as shown in the example-dataset-schedule workflow in development
+- `schedule`: [cron expression](https://crontab.guru/) that defines how often the workflow runs (defaults to `null`), can also use dataset scheduling as shown in the [example-dataset-schedule workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-dataset-schedule/workflow.yml)
 - `start_date`: the timestamp (`YYYY-MM-DD`) from which the scheduler will attempt to backfill (defaults to `2025-01-01`)
-- `inlets`: used to provide lineage when using dataset scheduling. An example is shown in the example-dataset-schedule worflow in development
-- `outlets`: used in conjunction with downstram dataset scheduling. An example is shown in the example-outlet worflow in development
+- `inlets`: used to provide lineage when using dataset scheduling. An example is shown in the [example-dataset-schedule workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-dataset-schedule/workflow.yml)
+- `outlets`: used in conjunction with downstram dataset scheduling. An example is shown in the [example-outlet workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-outlet/workflow.yml)
 
 
 The [`example-schedule` workflow](https://github.com/ministryofjustice/analytical-platform-airflow/blob/main/environments/development/analytical-platform/example-schedule/workflow.yml) shows an example of a workflow that runs at 08:00 every day and retries 3 times, with a 150 second delay between each retry:


### PR DESCRIPTION
This pull request:
- completes https://github.com/ministryofjustice/analytical-platform/issues/8150
- adds dataset scheduling, inlets and outlets to the Airflow user guidance, with references to example workflows in development

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>