### PR TITLE
fixed indentation so yaml block renders

### DIFF
--- a/source/documentation/services/airflow/index.md
+++ b/source/documentation/services/airflow/index.md
@@ -392,12 +392,12 @@ To enable Slack notifications, you need to:
 
 If you only want to receive notifications on success _or_ failure events you can add the slack_events parameter, e.g:
 
-    ```yaml
-    notifications:
-      slack_channel: your-channel-name # e.g. analytical-platform
-      slack_events:
-        - failure
-    ```
+```yaml
+notifications:
+  slack_channel: your-channel-name # e.g. analytical-platform
+  slack_events:
+    - failure
+```
 The above will only send notifications on workflow failures.
 
 If `slack_events` is not specified, notifications will be sent on both Success and Failure events.


### PR DESCRIPTION
Fixed indentation to allow the yaml block to render correctly 