### PR TITLE
Update pages to add disclaimer and correct support route

### DIFF
--- a/source/documentation/github/collaborate-on-project.md
+++ b/source/documentation/github/collaborate-on-project.md
@@ -1,5 +1,11 @@
 # Collaborate on a project
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 ### Working on a branch
 
 One of the most useful aspects of git is 'branching'.  This involves a few extra steps, but it enables some really important benefits:

--- a/source/documentation/github/command-line-git.md
+++ b/source/documentation/github/command-line-git.md
@@ -1,5 +1,11 @@
 # Work with git on the command line
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 The command line is the text interface to your Analytical Platform tools. When googling, it may also be referred to as the shell, terminal, or console (and perhaps other names). In Jupyter, you can get the command line by selecting 'Terminal' from the launcher screen (the + button in the top left of JupyterLab). You can also use all these commands in RStudio by going to Tools -> Terminal -> New Terminal. In Visual Studio Code, it's Terminal -> New Terminal.
 
 Once you are comfortable using the Terminal (in RStudio, Visual Studio Code or Jupyter) you can run all Git commands from the command line. If you are quite new to the command line, there are a few commands you may find useful to know, in addition to the git commands described later in this section:

--- a/source/documentation/github/create-project.md
+++ b/source/documentation/github/create-project.md
@@ -1,5 +1,11 @@
 # Create a new project in GitHub
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 In GitHub, you can use a repository to store and collaborate on all of your project's code.
 
 You can also use:

--- a/source/documentation/github/index.md
+++ b/source/documentation/github/index.md
@@ -1,5 +1,11 @@
 # Git and GitHub
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+>If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 ### What is git?
 
 [Git](https://git-scm.com/) is a distributed version control system. It allows you to track changes in files and directories, and to collaborate with others on code development.

--- a/source/documentation/github/install-packages.md
+++ b/source/documentation/github/install-packages.md
@@ -1,5 +1,11 @@
 # Install packages from GitHub
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 ### R packages
 
 When the visibility of a repository containing an R package is set to internal or private, you need to authenticate to GitHub to access it from R. Otherwise, you will get a 404 error.

--- a/source/documentation/github/jupyterlab-git.md
+++ b/source/documentation/github/jupyterlab-git.md
@@ -1,3 +1,9 @@
 # Work with git in JupyterLab
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+>If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 There is no git interface built into JupyterLab. You should use the [command line](command-line-git.html) instead.

--- a/source/documentation/github/learning-resources.md
+++ b/source/documentation/github/learning-resources.md
@@ -1,5 +1,11 @@
 # Learning resources
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 If you are new to git and you want to learn more, you may find the following resources useful:
 
 - The [GitHub training kit](https://training.github.com/), including the [git cheat sheet](https://training.github.com/downloads/github-git-cheat-sheet/) and the [GitHub training manual](https://githubtraining.github.io/training-manual/)

--- a/source/documentation/github/manage-access.md
+++ b/source/documentation/github/manage-access.md
@@ -1,12 +1,18 @@
 # Manage access in GitHub
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 Access to repositories in GitHub is managed via [teams](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams). You can set up teams in any way you like. Commonly, teams in GitHub correspond directly to team in the organisation or to a group of people that are working together on the same project. You can also nest teams in GitHub to mirror organisational structures and cascade permissions.
 
 You cannot provide direct access to repositories, except for [outside collaborators](../github/organisation-management.html#outside-collaborators). If you give a member direct access to a repository, they will [automatically be added to a team](../github/organisation-management.html#moving-members-with-direct-repository-access-to-teams) with the same permissions.
 
 ### About teams
 
-Invidividuals can be a member of a team or a maintainer of a team.
+Individuals can be a member of a team or a maintainer of a team.
 
 Maintainers can add and remove members from the team, and change the role of members in the team.
 

--- a/source/documentation/github/organisation-management.md
+++ b/source/documentation/github/organisation-management.md
@@ -1,5 +1,11 @@
 # GitHub organisation management
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 The MoJ Analytical Services GitHub organisation is managed by the Operations Engineering Team.
 
 ## Processes and practices

--- a/source/documentation/github/rstudio-git.md
+++ b/source/documentation/github/rstudio-git.md
@@ -1,5 +1,11 @@
 # Work with git in RStudio
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 Below are point and click steps you can use to sync with your new GitHub repo in RStudio. You can also use the [command line](command-line-git.html).
 
 ### Step 1: Navigate to your platform R Studio and make a copy of the Github project in your R Studio

--- a/source/documentation/github/security-in-github.md
+++ b/source/documentation/github/security-in-github.md
@@ -1,6 +1,12 @@
 # Security in GitHub
 
-### Protecting information in GitHub
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
+## Protecting information in GitHub
 
 GitHub should primarily be used to store code.
 
@@ -18,9 +24,9 @@ You can use the following approaches to reduce the risk of accidentally publishi
 | Pushing to repositories outside the MoJ Analytical Services GitHub organistion | [Pre-push hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) | You should only store code in the MoJ Analytical Services GitHub organisation. | Force push using `git push -f <remote> <branch>` |
 <div style="height:0px;font-size:0px;">&nbsp;</div>
 
-You should also not store secrets in GitHub, including passwords, credentials and keys. You can use [parameters](../parameters.html) to securely store secrets on the Analytical Platform.
+You should also not store secrets in GitHub, including passwords, credentials and keys. You can use [parameters](../parameters.html) to securely store secrets.
 
-### Accidentally publishing data to GitHub
+## Accidentally publishing data to GitHub
 
 If you accidentally publish sensitive data to GitHub, you should:
 

--- a/source/documentation/github/set-up-github.md
+++ b/source/documentation/github/set-up-github.md
@@ -1,5 +1,11 @@
 # Set up GitHub
 
+> This page contains general guidance about GitHub.
+>
+> It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
+>
+> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+
 To set up GitHub for use with git in RStudio or JupyterLab, you'll need to:
 
 1. [Create an SSH key](#create-an-ssh-key).
@@ -50,9 +56,9 @@ To add the SSH key to GitHub, you should follow the [guidance from GitHub](https
 
 You also need to authorise your SSH key for use with the MoJ-Analytical-Services organisation before you can use it; see [GitHub: Authorizing an SSH key](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-an-ssh-key-for-use-with-saml-single-sign-on#authorizing-an-ssh-key) for instructions.
 
-### Configure your username and email in git on the Analytical Platform
+### Configure your username and email in git
 
-To configure your username and email in git on the Analytical Platform using RStudio or JupyterLab, follow the steps below:
+To configure your username and email in git using RStudio or JupyterLab, follow the steps below:
 
 1.  Open a new terminal:
     - In RStudio, select **Tools** in the menu bar and then **Shell...**

--- a/source/github/collaborate-on-project.html.md.erb
+++ b/source/github/collaborate-on-project.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Collaborate on a project
 weight: 74
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/command-line-git.html.md.erb
+++ b/source/github/command-line-git.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Work with git on the command line
 weight: 77
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/create-project.html.md.erb
+++ b/source/github/create-project.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Create a new project in GitHub
 weight: 72
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/index.html.md.erb
+++ b/source/github/index.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Git and GitHub
 weight: 70
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/install-packages.html.md.erb
+++ b/source/github/install-packages.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Install packages from GitHub
 weight: 78
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/jupyterlab-git.html.md.erb
+++ b/source/github/jupyterlab-git.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Work with git and GitHub in JupyterLab
 weight: 76
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/learning-resources.html.md.erb
+++ b/source/github/learning-resources.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Learning resources
 weight: 81
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/manage-access.html.md.erb
+++ b/source/github/manage-access.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Manage access in GitHub
 weight: 73
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/organisation-management.html.md.erb
+++ b/source/github/organisation-management.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Organisation Management
 weight: 80
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-operations-engineering"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/rstudio-git.html.md.erb
+++ b/source/github/rstudio-git.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Work with git in RStudio
 weight: 75
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/security-in-github.html.md.erb
+++ b/source/github/security-in-github.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Security in GitHub
 weight: 79
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/github/set-up-github.html.md.erb
+++ b/source/github/set-up-github.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Setup GitHub
+title: Set up GitHub
 weight: 71
 last_reviewed_on: 2026-08-24
 review_in: 12 months

--- a/source/github/set-up-github.html.md.erb
+++ b/source/github/set-up-github.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Setup GitHub
 weight: 71
-last_reviewed_on: 2023-01-30
+last_reviewed_on: 2026-08-24
 review_in: 12 months
-owner_slack: "#analytical-platform-support"
+owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"
 ---
 


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/data-platform/issues/530 

## Changes
- Adds banner to general GitHub pages redirecting questions to #ask-about-github Slack channel
- Updates page ownership to #ask-about-github
- Corrected some small errors

Note: One page which does have information specific to the Analytical Platform is excluded from these changes: [Accessing private repositories from GitHub Actions](https://user-guidance.analytical-platform.service.justice.gov.uk/github/accessing-private-repositories-from-github-actions.html). 