### PR TITLE
Replace outdated refs to Ops Eng with DevX team

### DIFF
--- a/source/documentation/faq.md
+++ b/source/documentation/faq.md
@@ -23,8 +23,6 @@ Analytical Platform Applications hosted on Cloud Platform will use the IP addres
 
 ## I have been removed from the GitHub Organisation
 
-You will be notified of this action via an email from GitHub - "[GitHub] You've been removed from the "MoJ Analytical Services" organization".
+If this happens, GitHub will send you an email saying: 'You've been removed from the "MoJ Analytical Services" organization'.
 
-You were removed due to inactivity, as part of this Operations Engineering’s dormant GitHub user process noted [here](https://runbooks.operations-engineering.service.justice.gov.uk/documentation/services/github/remove-dormant-users.html).
- 
-To rejoin, you can use this link (https://github.com/orgs/moj-analytical-services/sso).
+You can [use this SSO link to rejoin the organisation](https://github.com/orgs/moj-analytical-services/sso).

--- a/source/documentation/github/index.md
+++ b/source/documentation/github/index.md
@@ -25,7 +25,7 @@ All code written on the Analytical Platform should be stored in a [git repositor
 
 ### Join GitHub
 
-If you do not have a GitHub account, you will be prompted to create one when you join the moj-analytical-services or ministryofjustice GitHub Organisations via SSO. [Click here](https://github.com/orgs/ministryofjustice/sso) to join the ministryofjustice Organisation. [Click here](https://github.com/orgs/moj-analytical-services/sso) to join the moj-analytical-services Organisation. If you experience any issues with the SSO process please contact [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4)
+If you do not have a GitHub account, you will be prompted to create one when you join the moj-analytical-services or ministryofjustice GitHub Organisations via SSO. [Click here](https://github.com/orgs/ministryofjustice/sso) to join the ministryofjustice Organisation. [Click here](https://github.com/orgs/moj-analytical-services/sso) to join the moj-analytical-services Organisation. If you experience any issues with the SSO process, [contact the Developer Experience team on Slack](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).
 
 ### Get started
 

--- a/source/documentation/github/manage-access.md
+++ b/source/documentation/github/manage-access.md
@@ -16,9 +16,9 @@ Individuals can be a member of a team or a maintainer of a team.
 
 Maintainers can add and remove members from the team, and change the role of members in the team.
 
-It is often useful for a team to have at least one maintainer. To add a maintainer to a team, contact the [Operations Engineering Team](../github/organisation-management.html#contact).
+It is often useful for a team to have at least one maintainer. To add a maintainer to a team, [contact the Developer Experience team on Slack](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).
 
-If your team has no maintainers, you can also ask the [Operations Engineering Team](../github/organisation-management.html#contact) to add and remove members on your behalf.
+If your team has no maintainers, you can also [contact the Developer Experience team on Slack](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8) to add and remove members on your behalf.
 
 ### Create a team
 

--- a/source/documentation/github/organisation-management.md
+++ b/source/documentation/github/organisation-management.md
@@ -4,9 +4,9 @@
 >
 > It's not specific to the Analytical Platform, and the Analytical Platform team cannot provide support or troubleshoot GitHub issues.
 >
-> If you need help, ask in the [#ask-about-github Slack channel](https://moj.enterprise.slack.com/archives/C08SV6MR2P7).
+> If you need help, ask in the [#ask-developer-experience Slack channel](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).
 
-The MoJ Analytical Services GitHub organisation is managed by the Operations Engineering Team.
+The MoJ Analytical Services GitHub organisation is managed by the Developer Experience team.
 
 ## Processes and practices
 
@@ -27,7 +27,7 @@ An outside collaborator is a person who is not a member of the organisation, but
 
 We use outside collaborators for external users, such as analysts from other government departments and partner organisations.
 
-To add an outside collaborator you must be a Repository Administrator. Repository Administrators can invite external collaborators directly from the [GitHub](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-outside-collaborators/adding-outside-collaborators-to-repositories-in-your-organization#adding-outside-collaborators-to-a-repository). Operations Engineering guidance relating to this is located [here](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/storing-source-code.html#member-of-the-moj-organisation).
+To add an outside collaborator you must be a repository administrator. Repository administrators can [invite external collaborators directly from GitHub](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-outside-collaborators/adding-outside-collaborators-to-repositories-in-your-organization#adding-outside-collaborators-to-a-repository). You can check [legacy guidance about adding outside collaborators](https://developer-portal.service.justice.gov.uk/docs/cloud-optimisation-and-accountability/operations-engineering-legacy/operations-engineering-user-guide/github/storing-source-code.html#outside-collaborator) until the Developer Experience team publishes updated guidance.
 
 ## Automation
 
@@ -37,7 +37,7 @@ All automated processes are managed in the [moj-analytical-services/operations-e
 
 GitHub repositories are automatically archived when there is no activity on the `main` or `master` branch for more than 1.5 years.
 
-If you still need a repository that has been archived, [contact](#contact) the Operations Engineering Team. Where a repository is inactive but should not be archived, it can be added to an allow list, so it is not archived again in future.
+If you still need a repository that has been archived, [contact the Developer Experience team on Slack](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8). Where a repository is inactive but should not be archived, it can be added to an allow list, so it is not archived again in future.
 
 ### Moving members with direct repository access to teams
 
@@ -45,7 +45,7 @@ Any members that only have direct access to a repository will be moved to a new 
 
 If a member has both direct access to a repository and access via a team, they will only retain access via the team. If the level of access provided by the team is less than the level of direct access, their level of access will be reduced. For example, if a member has direct admin access to a repository and read access via a team, they will only retain read access via the team.
 
-By default, members that are moved to teams will not be maintainers. Therefore, they will not be able to manage team permissions, including adding and removing members, and changing the role of members. You can request to be made a maintainer by [contacting](#contact) the Operations Engineering Team.
+By default, members that are moved to teams will not be maintainers. Therefore, they will not be able to manage team permissions, including adding and removing members, and changing the role of members. You can request to be made a maintainer by [contacting the Developer Experience team on Slack](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).
 
 ### Adding members to the everyone team
 
@@ -57,4 +57,4 @@ Occasionally, we will review active members of the GitHub organisation, and remo
 
 ## Contact
 
-The team can be contacted in the [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4) Slack channel or by email at [operations-engineering@digital.justice.gov.uk](mailto:operations-engineering@digital.justice.gov.uk).
+The team can be contacted in the [#ask-developer-experience Slack channel](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).

--- a/source/documentation/shared-responsibility-model.md
+++ b/source/documentation/shared-responsibility-model.md
@@ -45,7 +45,7 @@ Some responsibilities are shared between users and the Analytical Platform team 
 
 | Responsibility                                      | Analytical Platform | User  | Other MoJ Team | Notes                                                                                                                                                                   |
 | :--------------------------------------------------- | :-------------------: | :-----: | :--------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Managing Single-Sign On (SSO) access                | ✅                |  | ✅           | The Analytical Platform and Operations Engineering share the responsibilities of managing SSO access.<br><br> We report any changes to SSO via email and Slack. |
+| Managing Single-Sign On (SSO) access                | ✅                |  | ✅           | The Analytical Platform and Developer Experience teams share the responsibilities of managing SSO access.<br><br> We report any changes to SSO via email and Slack. |
 | Implementing, enforcing and managing security rules | ✅                |  |           | The Analytical Platform and Platforms & Architecture (P&A) Cyber team share the responsibilities of security rules.                                                |
 
 ## Tools and packages

--- a/source/faq.html.md.erb
+++ b/source/faq.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Frequently asked questions
 weight: 170
-last_reviewed_on: 2024-10-16
+last_reviewed_on: 2026-08-09
 review_in: 6 months
 owner_slack: "#analytical-platform"
 owner_slack_workspace: "mojdt"

--- a/source/github/index.html.md.erb
+++ b/source/github/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Git and GitHub
 weight: 70
-last_reviewed_on: 2026-08-24
+last_reviewed_on: 2026-09-08
 review_in: 12 months
 owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"

--- a/source/github/manage-access.html.md.erb
+++ b/source/github/manage-access.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Manage access in GitHub
 weight: 73
-last_reviewed_on: 2026-08-24
+last_reviewed_on: 2026-09-08
 review_in: 12 months
 owner_slack: "#ask-about-github"
 owner_slack_workspace: "mojdt"

--- a/source/github/organisation-management.html.md.erb
+++ b/source/github/organisation-management.html.md.erb
@@ -1,9 +1,9 @@
 ---
 title: Organisation Management
 weight: 80
-last_reviewed_on: 2026-08-24
+last_reviewed_on: 2026-09-08
 review_in: 12 months
-owner_slack: "#ask-operations-engineering"
+owner_slack: "#ask-developer-experience"
 owner_slack_workspace: "mojdt"
 ---
 

--- a/source/shared-responsibility-model.html.md.erb
+++ b/source/shared-responsibility-model.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Shared Responsibility Model
 weight: 150
-last_reviewed_on: 2026-01-13
+last_reviewed_on: 2026-09-08
 review_in: 6 months
 owner_slack: "#analytical-platform-support"
 owner_slack_workspace: "mojdt"


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/data-platform/issues/218

## Changes
- Update pages redirecting users by replacing Operations Engineering team with Developer Experience team
- Update or remove broken links with content's new location on Developer Portal